### PR TITLE
Update edn-rs for Deserialize and Errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ async = ["tokio", "futures"]
 
 [dependencies]
 reqwest = { version = "0.10.6", features = ["blocking"] }
-edn-rs = { version = "0.11.3", features = ["async"] }
+edn-rs = { version = "0.13.0", features = ["async"] }
 mockito = {version = "0.26", optional = true }
 chrono = "0.4"
 futures = {version = "0.3.5", optional = true }

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ let is_sql = client.query(query_is_sql.unwrap()).unwrap();
 * `with_full_results` is a builder function to define the flag `full-results?` as true. This allows your `query` response to return the whole document instead of only the searched keys. The result of the Query `{:query {:find [?user ?a] :where [[?user :first-name ?a]] :full-results? true}}` will be a `BTreeSet<Vec<String>>` like `([{:crux.db/id :fafilda, :first-name "Jorge", :last-name "Klaus"} "Jorge"])`, so the document will need further EDN parsing to become the document's struct.
 
 Errors are defined in the [`CruxError`](https://docs.rs/transistor/1.2.0/transistor/types/error/enum.CruxError.html) enum.
-* `ParseEdnError` is originated by `edn_rs` crate. The provided EDN did not match schema.
+* `EdnError` is a wrapper over `edn_rs::EdnError`.
 * `RequestError` is originated by `reqwest` crate. Failed to make HTTP request.
 * `QueryFormatError` is originated when the provided Query struct did not match schema.
 * `QueryError` is responsible for encapsulation the Stacktrace error from Crux response:

--- a/src/http.rs
+++ b/src/http.rs
@@ -9,7 +9,7 @@ use crate::types::{
     response::{EntityHistoryResponse, EntityTxResponse, TxLogResponse, TxLogsResponse},
 };
 use chrono::prelude::*;
-use edn_rs::{edn, Deserialize, Edn, Map, Serialize};
+use edn_rs::{edn, Edn, Map, Serialize};
 #[cfg(not(feature = "async"))]
 use reqwest::blocking;
 use reqwest::header::HeaderMap;
@@ -53,7 +53,7 @@ impl HttpClient {
             .send()?
             .text()?;
 
-        Ok(Deserialize::deserialize(&Edn::from_str(&resp)?)?)
+        Ok(edn_rs::from_str(&resp)?)
     }
 
     /// Function `tx_logs` requests endpoint `/tx-log` via `GET` and returns a list of all transactions
@@ -232,8 +232,7 @@ impl HttpClient {
             .send()?
             .text()?;
 
-        let edn = Edn::from_str(&resp)?;
-        let query_response: QueryResponse = Deserialize::deserialize(&edn)?;
+        let query_response: QueryResponse = edn_rs::from_str(&resp)?;
 
         Ok(query_response.0)
     }
@@ -262,7 +261,7 @@ impl HttpClient {
             .text()
             .await?;
 
-        Ok(Deserialize::deserialize(&Edn::from_str(&resp)?)?)
+        Ok(edn_rs::from_str(&resp)?)
     }
 
     pub async fn tx_logs(&self) -> Result<TxLogsResponse, CruxError> {
@@ -442,8 +441,7 @@ impl HttpClient {
             .text()
             .await?;
 
-        let edn = Edn::from_str(&resp)?;
-        let query_response: QueryAsyncResponse = Deserialize::deserialize(&edn)?;
+        let query_response: QueryAsyncResponse = edn_rs::from_str(&resp)?;
 
         Ok(query_response.0)
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -10,7 +10,9 @@ use crate::types::{
 };
 use chrono::prelude::*;
 use edn_rs::{edn, Deserialize, Edn, Map, Serialize};
-use reqwest::{blocking, header::HeaderMap};
+#[cfg(not(feature = "async"))]
+use reqwest::blocking;
+use reqwest::header::HeaderMap;
 use std::collections::BTreeSet;
 use std::str::FromStr;
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -53,8 +53,7 @@ impl HttpClient {
             .send()?
             .text()?;
 
-        edn_rs::from_str(&resp)
-            .map_err(|e| e.into())
+        edn_rs::from_str(&resp).map_err(|e| e.into())
     }
 
     /// Function `tx_logs` requests endpoint `/tx-log` via `GET` and returns a list of all transactions
@@ -262,8 +261,7 @@ impl HttpClient {
             .text()
             .await?;
 
-        edn_rs::from_str(&resp)
-            .map_err(|e| e.into())
+        edn_rs::from_str(&resp).map_err(|e| e.into())
     }
 
     pub async fn tx_logs(&self) -> Result<TxLogsResponse, CruxError> {

--- a/src/http.rs
+++ b/src/http.rs
@@ -53,7 +53,8 @@ impl HttpClient {
             .send()?
             .text()?;
 
-        Ok(edn_rs::from_str(&resp)?)
+        edn_rs::from_str(&resp)
+            .map_err(|e| e.into())
     }
 
     /// Function `tx_logs` requests endpoint `/tx-log` via `GET` and returns a list of all transactions
@@ -261,7 +262,8 @@ impl HttpClient {
             .text()
             .await?;
 
-        Ok(edn_rs::from_str(&resp)?)
+        edn_rs::from_str(&resp)
+            .map_err(|e| e.into())
     }
 
     pub async fn tx_logs(&self) -> Result<TxLogsResponse, CruxError> {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3,7 +3,7 @@ pub mod http;
 pub mod query;
 pub mod response;
 
-use edn_rs::{Serialize, Deserialize, Edn, EdnError};
+use edn_rs::{Deserialize, Edn, EdnError, Serialize};
 
 /// Id to use as reference in Crux, similar to `ids` with `Uuid`. This id is supposed to be a KEYWORD, `Edn::Key`.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
@@ -21,7 +21,10 @@ impl Deserialize for CruxId {
     fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
         match edn {
             Edn::Str(s) => Ok(Self::new(s)),
-            _ => Err(EdnError::Deserialize(format!("couldn't convert {} into CruxId", edn))),
+            _ => Err(EdnError::Deserialize(format!(
+                "couldn't convert {} into CruxId",
+                edn
+            ))),
         }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3,7 +3,7 @@ pub mod http;
 pub mod query;
 pub mod response;
 
-use edn_rs::Serialize;
+use edn_rs::{Serialize, Deserialize, Edn, EdnError};
 
 /// Id to use as reference in Crux, similar to `ids` with `Uuid`. This id is supposed to be a KEYWORD, `Edn::Key`.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
@@ -14,6 +14,15 @@ impl Serialize for CruxId {
         self.0.insert(0, ':');
 
         format!("{}", self.0.replace(" ", "-"))
+    }
+}
+
+impl Deserialize for CruxId {
+    fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
+        match edn {
+            Edn::Str(s) => Ok(Self::new(s)),
+            _ => Err(EdnError::Deserialize(format!("couldn't convert {} into CruxId", edn))),
+        }
     }
 }
 

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -72,7 +72,8 @@ impl FromStr for TxLogsResponse {
     type Err = CruxError;
     fn from_str(resp: &str) -> Result<Self, CruxError> {
         let clean_edn = resp.replace("#crux/id", "");
-        Ok(edn_rs::from_str(&clean_edn)?)
+        edn_rs::from_str(&clean_edn)
+            .map_err(|e| e.into())
     }
 }
 
@@ -112,7 +113,8 @@ impl FromStr for EntityTxResponse {
     type Err = CruxError;
     fn from_str(resp: &str) -> Result<Self, CruxError> {
         let clean_edn = resp.replace("#crux/id", "");
-        Ok(edn_rs::from_str(&clean_edn)?)
+        edn_rs::from_str(&clean_edn)
+            .map_err(|e| e.into())
     }
 }
 
@@ -323,7 +325,8 @@ impl FromStr for EntityHistoryResponse {
     type Err = CruxError;
     fn from_str(resp: &str) -> Result<Self, CruxError> {
         let clean_edn = resp.replace("#crux/id", "").replace("#inst", "");
-        Ok(edn_rs::from_str(&clean_edn)?)
+        edn_rs::from_str(&clean_edn)
+            .map_err(|e| e.into())
     }
 }
 

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -72,8 +72,7 @@ impl FromStr for TxLogsResponse {
     type Err = CruxError;
     fn from_str(resp: &str) -> Result<Self, CruxError> {
         let clean_edn = resp.replace("#crux/id", "");
-        edn_rs::from_str(&clean_edn)
-            .map_err(|e| e.into())
+        edn_rs::from_str(&clean_edn).map_err(|e| e.into())
     }
 }
 
@@ -113,8 +112,7 @@ impl FromStr for EntityTxResponse {
     type Err = CruxError;
     fn from_str(resp: &str) -> Result<Self, CruxError> {
         let clean_edn = resp.replace("#crux/id", "");
-        edn_rs::from_str(&clean_edn)
-            .map_err(|e| e.into())
+        edn_rs::from_str(&clean_edn).map_err(|e| e.into())
     }
 }
 
@@ -325,8 +323,7 @@ impl FromStr for EntityHistoryResponse {
     type Err = CruxError;
     fn from_str(resp: &str) -> Result<Self, CruxError> {
         let clean_edn = resp.replace("#crux/id", "").replace("#inst", "");
-        edn_rs::from_str(&clean_edn)
-            .map_err(|e| e.into())
+        edn_rs::from_str(&clean_edn).map_err(|e| e.into())
     }
 }
 

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -19,9 +19,9 @@ pub struct TxLogResponse {
 impl Deserialize for TxLogResponse {
     fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
         Ok(Self {
-            tx___tx_id: edn[":crux.tx/tx-id"].to_uint().unwrap_or(0usize),
+            tx___tx_id: Deserialize::deserialize(&edn[":crux.tx/tx-id"]).unwrap_or(0usize),
             #[cfg(feature = "time_as_str")]
-            tx___tx_time: edn[":crux.tx/tx-time"].to_string(),
+            tx___tx_time: Deserialize::deserialize(&edn[":crux.tx/tx-time"])?,
             #[cfg(not(feature = "time_as_str"))]
             tx___tx_time: edn[":crux.tx/tx-time"]
                 .to_string()
@@ -138,18 +138,18 @@ impl EntityTxResponse {
 impl Deserialize for EntityTxResponse {
     fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
         Ok(Self {
-            db___id: edn[":crux.db/id"].to_string(),
-            db___content_hash: edn[":crux.db/content-hash"].to_string(),
+            db___id: Deserialize::deserialize(&edn[":crux.db/id"])?,
+            db___content_hash: Deserialize::deserialize(&edn[":crux.db/content-hash"])?,
             #[cfg(feature = "time_as_str")]
-            db___valid_time: edn[":crux.db/valid-time"].to_string(),
+            db___valid_time: Deserialize::deserialize(&edn[":crux.db/valid-time"]),
             #[cfg(not(feature = "time_as_str"))]
             db___valid_time: edn[":crux.db/valid-time"]
                 .to_string()
                 .parse::<DateTime<FixedOffset>>()
                 .unwrap(),
-            tx___tx_id: edn[":crux.tx/tx-id"].to_uint().unwrap_or(0usize),
+            tx___tx_id: Deserialize::deserialize(&edn[":crux.tx/tx-id"]).unwrap_or(0usize),
             #[cfg(feature = "time_as_str")]
-            tx___tx_time: edn[":crux.tx/tx-time"].to_string(),
+            tx___tx_time: Deserialize::deserialize(&edn[":crux.tx/tx-time"]),
             #[cfg(not(feature = "time_as_str"))]
             tx___tx_time: edn[":crux.tx/tx-time"]
                 .to_string()
@@ -263,17 +263,17 @@ pub struct EntityHistoryElement {
 impl Deserialize for EntityHistoryElement {
     fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
         Ok(Self {
-            db___content_hash: edn[":crux.db/content-hash"].to_string(),
+            db___content_hash: Deserialize::deserialize(&edn[":crux.db/content-hash"])?,
             #[cfg(feature = "time_as_str")]
-            db___valid_time: edn[":crux.db/valid-time"].to_string(),
+            db___valid_time: Deserialize::deserialize(&edn[":crux.db/valid-time"])?,
             #[cfg(not(feature = "time_as_str"))]
             db___valid_time: edn[":crux.db/valid-time"]
                 .to_string()
                 .parse::<DateTime<FixedOffset>>()
                 .unwrap(),
-            tx___tx_id: edn[":crux.tx/tx-id"].to_uint().unwrap_or(0usize),
+            tx___tx_id: Deserialize::deserialize(&edn[":crux.tx/tx-id"]).unwrap_or(0usize),
             #[cfg(feature = "time_as_str")]
-            tx___tx_time: edn[":crux.tx/tx-time"].to_string(),
+            tx___tx_time: Deserialize::deserialize(&edn[":crux.tx/tx-time"])?,
             #[cfg(not(feature = "time_as_str"))]
             tx___tx_time: edn[":crux.tx/tx-time"]
                 .to_string()

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -1,7 +1,8 @@
 use crate::types::error::CruxError;
 use chrono::prelude::*;
-use edn_rs::{from_str, Edn};
+use edn_rs::{Deserialize, Edn, EdnError};
 use std::collections::BTreeSet;
+use std::str::FromStr;
 
 #[derive(Debug, PartialEq, Clone)]
 #[allow(non_snake_case)]
@@ -15,12 +16,39 @@ pub struct TxLogResponse {
     pub tx__event___tx_events: Option<Vec<Vec<String>>>,
 }
 
-impl TxLogResponse {
-    pub fn deserialize(resp: String) -> Result<Self, CruxError> {
-        let edn = from_str(&resp)?;
-        Ok(edn.into())
+impl Deserialize for TxLogResponse {
+    fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
+        Ok(Self {
+            tx___tx_id: edn[":crux.tx/tx-id"].to_uint().unwrap_or(0usize),
+            #[cfg(feature = "time_as_str")]
+            tx___tx_time: edn[":crux.tx/tx-time"].to_string(),
+            #[cfg(not(feature = "time_as_str"))]
+            tx___tx_time: edn[":crux.tx/tx-time"]
+                .to_string()
+                .parse::<DateTime<FixedOffset>>()
+                .unwrap(),
+            tx__event___tx_events: match edn.get(":crux.tx.event/tx-events") {
+                Some(e) => Some(
+                    e.iter()
+                        .ok_or(EdnError::Deserialize(format!(
+                            "The following Edn cannot be deserialized to TxLog: {:?}",
+                            edn
+                        )))?
+                        .map(|el| {
+                            el.to_vec().ok_or(EdnError::Deserialize(format!(
+                                "The following Edn cannot be deserialized to Vec: {:?}",
+                                edn
+                            )))
+                        })
+                        .collect::<Result<Vec<Vec<String>>, EdnError>>()?,
+                ),
+                None => None,
+            },
+        })
     }
+}
 
+impl TxLogResponse {
     #[cfg(test)]
     pub fn default() -> Self {
         Self {
@@ -40,52 +68,27 @@ pub struct TxLogsResponse {
     pub tx_events: Vec<TxLogResponse>,
 }
 
-impl TxLogsResponse {
-    pub fn deserialize(resp: String) -> Result<Self, CruxError> {
+impl FromStr for TxLogsResponse {
+    type Err = CruxError;
+    fn from_str(resp: &str) -> Result<Self, CruxError> {
         let clean_edn = resp.replace("#crux/id", "");
-        let edn = from_str(&clean_edn)?;
-        Ok(edn.into())
+        let edn = Edn::from_str(&clean_edn)?;
+        Ok(Deserialize::deserialize(&edn)?)
     }
 }
 
-impl From<Edn> for TxLogsResponse {
-    fn from(edn: Edn) -> Self {
-        Self {
+impl Deserialize for TxLogsResponse {
+    fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
+        Ok(Self {
             tx_events: edn
                 .iter()
-                .ok_or(CruxError::ParseEdnError(format!(
-                    "The following Edn cannot be parsed to TxLogs: {:?}",
+                .ok_or(EdnError::Deserialize(format!(
+                    "The following Edn cannot be deserialized to TxLogs: {:?}",
                     edn
-                )))
-                .unwrap()
-                .map(|e| e.to_owned().into())
-                .collect::<Vec<TxLogResponse>>(),
-        }
-    }
-}
-
-impl From<Edn> for TxLogResponse {
-    fn from(edn: Edn) -> Self {
-        Self {
-            tx___tx_id: edn[":crux.tx/tx-id"].to_uint().unwrap_or(0usize),
-            #[cfg(feature = "time_as_str")]
-            tx___tx_time: edn[":crux.tx/tx-time"].to_string(),
-            #[cfg(not(feature = "time_as_str"))]
-            tx___tx_time: edn[":crux.tx/tx-time"]
-                .to_string()
-                .parse::<DateTime<FixedOffset>>()
-                .unwrap(),
-            tx__event___tx_events: edn.get(":crux.tx.event/tx-events").map(|e| {
-                e.iter()
-                    .ok_or(CruxError::ParseEdnError(format!(
-                        "The following Edn cannot be parsed to TxLog: {:?}",
-                        edn
-                    )))
-                    .unwrap()
-                    .map(|el| el.to_vec().unwrap())
-                    .collect::<Vec<Vec<String>>>()
-            }),
-        }
+                )))?
+                .map(Deserialize::deserialize)
+                .collect::<Result<Vec<TxLogResponse>, EdnError>>()?,
+        })
     }
 }
 
@@ -106,13 +109,16 @@ pub struct EntityTxResponse {
     pub tx___tx_time: DateTime<FixedOffset>,
 }
 
-impl EntityTxResponse {
-    pub fn deserialize(resp: String) -> Result<Self, CruxError> {
+impl FromStr for EntityTxResponse {
+    type Err = CruxError;
+    fn from_str(resp: &str) -> Result<Self, CruxError> {
         let clean_edn = resp.replace("#crux/id", "");
-        let edn = from_str(&clean_edn)?;
-        Ok(edn.into())
+        let edn = Edn::from_str(&clean_edn)?;
+        Ok(Deserialize::deserialize(&edn)?)
     }
+}
 
+impl EntityTxResponse {
     #[cfg(test)]
     pub fn default() -> Self {
         Self {
@@ -129,9 +135,9 @@ impl EntityTxResponse {
     }
 }
 
-impl From<Edn> for EntityTxResponse {
-    fn from(edn: Edn) -> Self {
-        Self {
+impl Deserialize for EntityTxResponse {
+    fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
+        Ok(Self {
             db___id: edn[":crux.db/id"].to_string(),
             db___content_hash: edn[":crux.db/content-hash"].to_string(),
             #[cfg(feature = "time_as_str")]
@@ -149,36 +155,47 @@ impl From<Edn> for EntityTxResponse {
                 .to_string()
                 .parse::<DateTime<FixedOffset>>()
                 .unwrap(),
-        }
+        })
     }
 }
 
 #[doc(hidden)]
 #[cfg(not(feature = "async"))]
-pub(crate) struct QueryResponse;
+pub(crate) struct QueryResponse(pub(crate) BTreeSet<Vec<String>>);
 
 #[cfg(not(feature = "async"))]
-impl QueryResponse {
-    pub(crate) fn deserialize(resp: String) -> Result<BTreeSet<Vec<String>>, CruxError> {
-        let edn = from_str(&resp.clone())?;
+impl Deserialize for QueryResponse {
+    fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
         if edn.set_iter().is_some() {
-            Ok(edn
-                .set_iter()
-                .ok_or(CruxError::ParseEdnError(format!(
-                    "The following Edn cannot be parsed to BTreeSet: {:?}",
-                    edn
-                )))?
-                .map(|e| e.to_vec().unwrap())
-                .collect::<BTreeSet<Vec<String>>>())
+            Ok(Self(
+                edn.set_iter()
+                    .ok_or(EdnError::Deserialize(format!(
+                        "The following Edn cannot be deserialized to BTreeSet: {:?}",
+                        edn
+                    )))?
+                    .map(|e| {
+                        e.to_vec().ok_or(EdnError::Deserialize(format!(
+                            "The following Edn cannot be deserialized to Vec: {:?}",
+                            edn
+                        )))
+                    })
+                    .collect::<Result<BTreeSet<Vec<String>>, EdnError>>()?,
+            ))
         } else {
-            Ok(edn
-                .iter()
-                .ok_or(CruxError::ParseEdnError(format!(
-                    "The following Edn cannot be parsed to BTreeSet: {:?}",
-                    edn
-                )))?
-                .map(|e| e.to_vec().unwrap())
-                .collect::<BTreeSet<Vec<String>>>())
+            Ok(Self(
+                edn.iter()
+                    .ok_or(EdnError::Deserialize(format!(
+                        "The following Edn cannot be deserialized to BTreeSet: {:?}",
+                        edn
+                    )))?
+                    .map(|e| {
+                        e.to_vec().ok_or(EdnError::Deserialize(format!(
+                            "The following Edn cannot be deserialized to Vec: {:?}",
+                            edn
+                        )))
+                    })
+                    .collect::<Result<BTreeSet<Vec<String>>, EdnError>>()?,
+            ))
         }
     }
 }
@@ -186,36 +203,43 @@ impl QueryResponse {
 #[cfg(feature = "async")]
 #[derive(Clone, Debug, PartialEq)]
 /// When feature `async` is enabled this is the response type for endpoint `/query`.
-pub struct QueryAsyncResponse(BTreeSet<Vec<String>>);
+pub struct QueryAsyncResponse(pub(crate) BTreeSet<Vec<String>>);
 
 #[cfg(feature = "async")]
-impl QueryAsyncResponse {
-    pub(crate) fn deserialize(resp: String) -> QueryAsyncResponse {
-        let edn = from_str(&resp.clone()).unwrap();
+impl Deserialize for QueryAsyncResponse {
+    fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
         if edn.set_iter().is_some() {
-            QueryAsyncResponse {
+            Ok(Self {
                 0: edn
                     .set_iter()
-                    .ok_or(CruxError::ParseEdnError(format!(
-                        "The following Edn cannot be parsed to BTreeSet: {:?}",
+                    .ok_or(EdnError::Deserialize(format!(
+                        "The following Edn cannot be deserialize to BTreeSet: {:?}",
                         edn
-                    )))
-                    .unwrap()
-                    .map(|e| e.to_vec().unwrap())
-                    .collect::<BTreeSet<Vec<String>>>(),
-            }
+                    )))?
+                    .map(|e| {
+                        e.to_vec().ok_or(EdnError::Deserialize(format!(
+                            "The following Edn cannot be deserialized to Vec: {:?}",
+                            edn
+                        )))
+                    })
+                    .collect::<Result<BTreeSet<Vec<String>>, EdnError>>()?,
+            })
         } else {
-            QueryAsyncResponse {
+            Ok(Self {
                 0: edn
                     .iter()
-                    .ok_or(CruxError::ParseEdnError(format!(
-                        "The following Edn cannot be parsed to BTreeSet: {:?}",
+                    .ok_or(EdnError::Deserialize(format!(
+                        "The following Edn cannot be deserialize to BTreeSet: {:?}",
                         edn
-                    )))
-                    .unwrap()
-                    .map(|e| e.to_vec().unwrap())
-                    .collect::<BTreeSet<Vec<String>>>(),
-            }
+                    )))?
+                    .map(|e| {
+                        e.to_vec().ok_or(EdnError::Deserialize(format!(
+                            "The following Edn cannot be deserialized to Vec: {:?}",
+                            edn
+                        )))
+                    })
+                    .collect::<Result<BTreeSet<Vec<String>>, EdnError>>()?,
+            })
         }
     }
 }
@@ -234,6 +258,30 @@ pub struct EntityHistoryElement {
     pub tx___tx_time: DateTime<FixedOffset>,
     pub db___content_hash: String,
     pub db__doc: Option<Edn>,
+}
+
+impl Deserialize for EntityHistoryElement {
+    fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
+        Ok(Self {
+            db___content_hash: edn[":crux.db/content-hash"].to_string(),
+            #[cfg(feature = "time_as_str")]
+            db___valid_time: edn[":crux.db/valid-time"].to_string(),
+            #[cfg(not(feature = "time_as_str"))]
+            db___valid_time: edn[":crux.db/valid-time"]
+                .to_string()
+                .parse::<DateTime<FixedOffset>>()
+                .unwrap(),
+            tx___tx_id: edn[":crux.tx/tx-id"].to_uint().unwrap_or(0usize),
+            #[cfg(feature = "time_as_str")]
+            tx___tx_time: edn[":crux.tx/tx-time"].to_string(),
+            #[cfg(not(feature = "time_as_str"))]
+            tx___tx_time: edn[":crux.tx/tx-time"]
+                .to_string()
+                .parse::<DateTime<FixedOffset>>()
+                .unwrap(),
+            db__doc: edn.get(":crux.db/doc").map(|d| d.to_owned()),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -267,56 +315,32 @@ impl EntityHistoryElement {
     }
 }
 
-impl From<Edn> for EntityHistoryElement {
-    fn from(edn: Edn) -> Self {
-        Self {
-            db___content_hash: edn[":crux.db/content-hash"].to_string(),
-            #[cfg(feature = "time_as_str")]
-            db___valid_time: edn[":crux.db/valid-time"].to_string(),
-            #[cfg(not(feature = "time_as_str"))]
-            db___valid_time: edn[":crux.db/valid-time"]
-                .to_string()
-                .parse::<DateTime<FixedOffset>>()
-                .unwrap(),
-            tx___tx_id: edn[":crux.tx/tx-id"].to_uint().unwrap_or(0usize),
-            #[cfg(feature = "time_as_str")]
-            tx___tx_time: edn[":crux.tx/tx-time"].to_string(),
-            #[cfg(not(feature = "time_as_str"))]
-            tx___tx_time: edn[":crux.tx/tx-time"]
-                .to_string()
-                .parse::<DateTime<FixedOffset>>()
-                .unwrap(),
-            db__doc: edn.get(":crux.db/doc").map(|d| d.to_owned()),
-        }
-    }
-}
-
 /// Definition for the response of a `GET` at `/entity-history` endpoint. This returns a Vec of  `EntityHistoryElement`.
 #[derive(Debug, PartialEq, Clone)]
 pub struct EntityHistoryResponse {
     pub history: Vec<EntityHistoryElement>,
 }
 
-impl EntityHistoryResponse {
-    pub fn deserialize(resp: String) -> Result<Self, CruxError> {
+impl FromStr for EntityHistoryResponse {
+    type Err = CruxError;
+    fn from_str(resp: &str) -> Result<Self, CruxError> {
         let clean_edn = resp.replace("#crux/id", "").replace("#inst", "");
-        let edn = from_str(&clean_edn)?;
-        Ok(edn.into())
+        let edn = Edn::from_str(&clean_edn)?;
+        Ok(Deserialize::deserialize(&edn)?)
     }
 }
 
-impl From<Edn> for EntityHistoryResponse {
-    fn from(edn: Edn) -> Self {
-        Self {
+impl Deserialize for EntityHistoryResponse {
+    fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
+        Ok(Self {
             history: edn
                 .iter()
-                .ok_or(CruxError::ParseEdnError(format!(
-                    "The following Edn cannot be parsed to entity-history: {:?}",
+                .ok_or(EdnError::Deserialize(format!(
+                    "The following Edn cannot be deserialize to entity-history: {:?}",
                     edn
-                )))
-                .unwrap()
-                .map(|el| el.to_owned().into())
-                .collect::<Vec<EntityHistoryElement>>(),
-        }
+                )))?
+                .map(Deserialize::deserialize)
+                .collect::<Result<Vec<EntityHistoryElement>, EdnError>>()?,
+        })
     }
 }

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -72,8 +72,7 @@ impl FromStr for TxLogsResponse {
     type Err = CruxError;
     fn from_str(resp: &str) -> Result<Self, CruxError> {
         let clean_edn = resp.replace("#crux/id", "");
-        let edn = Edn::from_str(&clean_edn)?;
-        Ok(Deserialize::deserialize(&edn)?)
+        Ok(edn_rs::from_str(&clean_edn)?)
     }
 }
 
@@ -113,8 +112,7 @@ impl FromStr for EntityTxResponse {
     type Err = CruxError;
     fn from_str(resp: &str) -> Result<Self, CruxError> {
         let clean_edn = resp.replace("#crux/id", "");
-        let edn = Edn::from_str(&clean_edn)?;
-        Ok(Deserialize::deserialize(&edn)?)
+        Ok(edn_rs::from_str(&clean_edn)?)
     }
 }
 
@@ -325,8 +323,7 @@ impl FromStr for EntityHistoryResponse {
     type Err = CruxError;
     fn from_str(resp: &str) -> Result<Self, CruxError> {
         let clean_edn = resp.replace("#crux/id", "").replace("#inst", "");
-        let edn = Edn::from_str(&clean_edn)?;
-        Ok(Deserialize::deserialize(&edn)?)
+        Ok(edn_rs::from_str(&clean_edn)?)
     }
 }
 


### PR DESCRIPTION
So, I've done a lot of things in this PR, they are:

- Replaced all `From<Edn>` in favor of `edn_rs::Deserialize` trait;
- Removed a lot of `unwrap`s since `From<Edn>` didn't support errors;
- Implemented `std::str::FromStr` for types which needed to change the Edn String before converting it to the Edn struct, like replacing `#inst`s and things like that;
- Replaced `CruxError::ParseEdnError` in favor of a full wrapper over `edn_rs::EdnError`;
- Started using `EdnError::Deserialize` in places there was `EdnError::ParseEdn`, since it fits more the deserialization problems;
- Fixed `async query_response` return, which had a different interface from the `sync` version (one was a `BTreeSet`, the other a struct);
- Added conditional compilation for `reqwest::blocking` on `async` feature.

If it is really bad to review, please tell me that I will try to divide things better on commits.