### PR TITLE
Add missing Edn::Key deserialization for CruxId

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -20,6 +20,7 @@ impl Serialize for CruxId {
 impl Deserialize for CruxId {
     fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
         match edn {
+            Edn::Key(k) => Ok(Self::new(k)),
             Edn::Str(s) => Ok(Self::new(s)),
             _ => Err(EdnError::Deserialize(format!(
                 "couldn't convert {} into CruxId",


### PR DESCRIPTION
Since `CruxId` actually comes as a EDN keyword from Crux, we should convert from it as well on deserialization.

(one more bug found in smaug hehe)

![keys-gif-simpsons](https://media.giphy.com/media/3orif9Yd7sPJR8mUxO/giphy.gif)