### PR TITLE
Housekeeping 🏠

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ async = ["tokio", "futures"]
 
 [dependencies]
 reqwest = { version = "0.10.6", features = ["blocking"] }
-edn-rs = { version = "0.15.1", features = ["async"]}
+edn-rs = { version = "0.16.2", features = ["async"]}
 mockito = {version = "0.26", optional = true }
 chrono = "0.4"
 futures = {version = "0.3.5", optional = true }

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ let person2 = Person {
     ..
 };
 
-let action1 = Action::Put(person1.serialize());
-let action2 = Action::Put(person2.serialize());
+let action1 = Action::Put(edn_rs::to_string(person1));
+let action2 = Action::Put(edn_rs::to_string(person2));
 
 let body = client.tx_log(vec![action1, action2]).unwrap();
 // {:crux.tx/tx-id 7, :crux.tx/tx-time #inst \"2020-07-16T21:50:39.309-00:00\"}
@@ -147,7 +147,7 @@ let person = Person {
 
 let client = Crux::new("localhost", "3000").http_client();
 
-let edn_body = client.entity(person.crux__db___id.serialize()).unwrap();
+let edn_body = client.entity(edn_rs::to_string(person.crux__db___id)).unwrap();
 // Map(
 //     Map(
 //         {
@@ -180,7 +180,7 @@ let person = Person {
 
 let client = Crux::new("localhost", "3000").http_client();
 
-let tx_body = client.entity_tx(person.crux__db___id.serialize()).unwrap();
+let tx_body = client.entity_tx(edn_rs::to_string(person.crux__db___id)).unwrap();
 // EntityTxResponse {
 //     db___id: "d72ccae848ce3a371bd313865cedc3d20b1478ca",
 //     db___content_hash: "1828ebf4466f98ea3f5252a58734208cd0414376",
@@ -204,7 +204,7 @@ let person = Person {
 
 let client = Crux::new("localhost", "3000").http_client();
 
-let tx_body = client.entity_tx(person.crux__db___id.serialize()).unwrap();
+let tx_body = client.entity_tx(edn_rs::to_string(person.crux__db___id)).unwrap();
 
 let entity_history = client.entity_history(tx_body.db___id.clone(), Order::Asc, true);
 // EntityHistoryResponse { history: [
@@ -346,7 +346,7 @@ fn mock_client() {
         /// ...
     };
 
-    let actions = vec![Action::Put(person1.serialize()), Action::Put(person2.serialize())];
+    let actions = vec![Action::Put(edn_rs::to_string(person1)), Action::Put(edn_rs::to_string(person2))];
     
     let body = Crux::new("localhost", "3000")
         .http_mock()
@@ -414,9 +414,9 @@ async fn main() {
     };
 
     let client = Crux::new("localhost", "3000").http_client();
-    let action1 = Action::Put(crux.serialize(), None);
-    let action2 = Action::Put(psql.serialize(), None);
-    let action3 = Action::Put(mysql.serialize(), None);
+    let action1 = Action::Put(edn_rs::to_string(crux), None);
+    let action2 = Action::Put(edn_rs::to_string(psql), None);
+    let action3 = Action::Put(edn_rs::to_string(mysql), None);
 
     let _ = client.tx_log(vec![action1, action2, action3]).await;
 

--- a/examples/async_entity_history_timed.rs
+++ b/examples/async_entity_history_timed.rs
@@ -37,20 +37,23 @@ async fn main() {
     let _ = Crux::new("localhost", "3000")
         .http_client()
         .tx_log(vec![action1, action2])
-        .await;
+        .await
+        .unwrap();
 
     let tx_body = client
         .entity_tx(edn_rs::to_string(person1.crux__db___id))
-        .await;
+        .await
+        .unwrap();
 
     let entity_history = client
         .entity_history_timed(
-            tx_body.unwrap().db___id.clone(),
+            tx_body.db___id.clone(),
             Order::Asc,
             true,
             vec![time_history],
         )
-        .await;
+        .await
+        .unwrap();
 
     println!("{:#?}", entity_history);
     // EntityHistoryResponse {

--- a/examples/async_entity_history_timed.rs
+++ b/examples/async_entity_history_timed.rs
@@ -31,15 +31,17 @@ async fn main() {
         .unwrap();
     let time_history = TimeHistory::ValidTime(Some(start_timed), Some(end_timed));
 
-    let action1 = Action::Put(person1.clone().serialize(), Some(timed));
-    let action2 = Action::Put(person2.serialize(), Some(timed));
+    let action1 = Action::Put(edn_rs::to_string(person1.clone()), Some(timed));
+    let action2 = Action::Put(edn_rs::to_string(person2), Some(timed));
 
     let _ = Crux::new("localhost", "3000")
         .http_client()
         .tx_log(vec![action1, action2])
         .await;
 
-    let tx_body = client.entity_tx(person1.crux__db___id.serialize()).await;
+    let tx_body = client
+        .entity_tx(edn_rs::to_string(person1.crux__db___id))
+        .await;
 
     let entity_history = client
         .entity_history_timed(

--- a/examples/async_entity_timed.rs
+++ b/examples/async_entity_timed.rs
@@ -29,11 +29,13 @@ async fn main() {
     let _ = Crux::new("localhost", "3000")
         .http_client()
         .tx_log(vec![action1, action2])
-        .await;
+        .await
+        .unwrap();
 
     let edn_body = client
         .entity_timed(edn_rs::to_string(person1.crux__db___id), None, Some(timed))
-        .await;
+        .await
+        .unwrap();
 
     println!("\n Edn Body = {:#?}", edn_body);
     // Edn Body = Map(
@@ -52,10 +54,7 @@ async fn main() {
     //     ),
     // )
 
-    println!(
-        "\n Person Parsed Response = {:#?}",
-        Person::from(edn_body.unwrap())
-    );
+    println!("\n Person Parsed Response = {:#?}", Person::from(edn_body));
     // Person Parsed Response = Person {
     //     crux__db___id: CruxId(
     //         ":hello-entity",

--- a/examples/async_entity_timed.rs
+++ b/examples/async_entity_timed.rs
@@ -23,8 +23,8 @@ async fn main() {
         .parse::<DateTime<FixedOffset>>()
         .unwrap();
 
-    let action1 = Action::Put(person1.clone().serialize(), Some(timed));
-    let action2 = Action::Put(person2.serialize(), Some(timed));
+    let action1 = Action::Put(edn_rs::to_string(person1.clone()), Some(timed));
+    let action2 = Action::Put(edn_rs::to_string(person2), Some(timed));
 
     let _ = Crux::new("localhost", "3000")
         .http_client()
@@ -32,7 +32,7 @@ async fn main() {
         .await;
 
     let edn_body = client
-        .entity_timed(person1.crux__db___id.serialize(), None, Some(timed))
+        .entity_timed(edn_rs::to_string(person1.crux__db___id), None, Some(timed))
         .await;
 
     println!("\n Edn Body = {:#?}", edn_body);

--- a/examples/async_entity_timed.rs
+++ b/examples/async_entity_timed.rs
@@ -1,6 +1,6 @@
 use chrono::prelude::*;
 use transistor::client::Crux;
-use transistor::edn_rs::{ser_struct, Serialize};
+use transistor::edn_rs::{ser_struct, Serialize, Deserialize, EdnError};
 use transistor::types::http::Action;
 use transistor::types::CruxId;
 
@@ -54,7 +54,7 @@ async fn main() {
     //     ),
     // )
 
-    println!("\n Person Parsed Response = {:#?}", Person::from(edn_body));
+    println!("\n Person Parsed Response = {:#?}", edn_rs::from_edn::<Person>(&edn_body));
     // Person Parsed Response = Person {
     //     crux__db___id: CruxId(
     //         ":hello-entity",
@@ -74,12 +74,12 @@ ser_struct! {
     }
 }
 
-impl From<edn_rs::Edn> for Person {
-    fn from(edn: edn_rs::Edn) -> Self {
-        Self {
-            crux__db___id: CruxId::new(&edn[":crux.db/id"].to_string()),
-            first_name: edn[":first-name"].to_string(),
-            last_name: edn[":last-name"].to_string(),
-        }
+impl Deserialize for Person {
+    fn deserialize(edn: &edn_rs::Edn) -> Result<Self, EdnError> {
+        Ok(Self {
+            crux__db___id: edn_rs::from_edn(&edn[":crux.db/id"])?,
+            first_name: edn_rs::from_edn(&edn[":first-name"])?,
+            last_name: edn_rs::from_edn(&edn[":last-name"])?,
+        })
     }
 }

--- a/examples/async_entity_tx_timed.rs
+++ b/examples/async_entity_tx_timed.rs
@@ -29,11 +29,13 @@ async fn main() {
     let _ = Crux::new("localhost", "3000")
         .http_client()
         .tx_log(vec![action1, action2])
-        .await;
+        .await
+        .unwrap();
 
     let edn_body = client
         .entity_tx_timed(edn_rs::to_string(person1.crux__db___id), None, Some(timed))
-        .await;
+        .await
+        .unwrap();
 
     println!("\n Edn Body = {:#?}", edn_body);
     // Edn Body = Map(

--- a/examples/async_entity_tx_timed.rs
+++ b/examples/async_entity_tx_timed.rs
@@ -23,8 +23,8 @@ async fn main() {
         .parse::<DateTime<FixedOffset>>()
         .unwrap();
 
-    let action1 = Action::Put(person1.clone().serialize(), Some(timed));
-    let action2 = Action::Put(person2.serialize(), Some(timed));
+    let action1 = Action::Put(edn_rs::to_string(person1.clone()), Some(timed));
+    let action2 = Action::Put(edn_rs::to_string(person2), Some(timed));
 
     let _ = Crux::new("localhost", "3000")
         .http_client()
@@ -32,7 +32,7 @@ async fn main() {
         .await;
 
     let edn_body = client
-        .entity_tx_timed(person1.crux__db___id.serialize(), None, Some(timed))
+        .entity_tx_timed(edn_rs::to_string(person1.crux__db___id), None, Some(timed))
         .await;
 
     println!("\n Edn Body = {:#?}", edn_body);

--- a/examples/async_entity_tx_timed.rs
+++ b/examples/async_entity_tx_timed.rs
@@ -1,6 +1,6 @@
 use chrono::prelude::*;
 use transistor::client::Crux;
-use transistor::edn_rs::{ser_struct, Serialize};
+use transistor::edn_rs::{ser_struct, Serialize, Deserialize, EdnError};
 use transistor::types::http::Action;
 use transistor::types::CruxId;
 
@@ -65,12 +65,12 @@ ser_struct! {
     }
 }
 
-impl From<edn_rs::Edn> for Person {
-    fn from(edn: edn_rs::Edn) -> Self {
-        Self {
-            crux__db___id: CruxId::new(&edn[":crux.db/id"].to_string()),
-            first_name: edn[":first-name"].to_string(),
-            last_name: edn[":last-name"].to_string(),
-        }
+impl Deserialize for Person {
+    fn deserialize(edn: &edn_rs::Edn) -> Result<Self, EdnError> {
+        Ok(Self {
+            crux__db___id: edn_rs::from_edn(&edn[":crux.db/id"])?,
+            first_name: edn_rs::from_edn(&edn[":first-name"])?,
+            last_name: edn_rs::from_edn(&edn[":last-name"])?,
+        })
     }
 }

--- a/examples/async_query.rs
+++ b/examples/async_query.rs
@@ -28,7 +28,10 @@ async fn main() {
     let action2 = Action::Put(edn_rs::to_string(psql), None);
     let action3 = Action::Put(edn_rs::to_string(mysql), None);
 
-    let _ = client.tx_log(vec![action1, action2, action3]).await;
+    let _ = client
+        .tx_log(vec![action1, action2, action3])
+        .await
+        .unwrap();
 
     let query_is_sql = Query::find(vec!["?p1", "?n"])
         .unwrap()
@@ -36,7 +39,7 @@ async fn main() {
         .unwrap()
         .build();
 
-    let is_sql = client.query(query_is_sql.unwrap()).await;
+    let is_sql = client.query(query_is_sql.unwrap()).await.unwrap();
     println!("{:?}", is_sql);
     // QueryAsyncResponse({[":mysql", "MySQL"], [":postgres", "Postgres"]}) BTreeSet
 
@@ -45,9 +48,10 @@ async fn main() {
         .where_clause(vec!["?p1 :name ?n", "?p1 :is-sql ?s", "?p1 :is-sql false"])
         .unwrap()
         .with_full_results()
-        .build();
+        .build()
+        .unwrap();
 
-    let is_no_sql = client.query(query_is_no_sql.unwrap()).await;
+    let is_no_sql = client.query(query_is_no_sql).await.unwrap();
     println!("{:?}", is_no_sql);
     // {["{:crux.db/id: Key(\":cassandra\"), :is-sql: Bool(false), :name: Str(\"Cassandra\"), }", "Cassandra", "false"],
     //  ["{:crux.db/id: Key(\":crux\"), :is-sql: Bool(false), :name: Str(\"Crux Datalog\"), }", "Crux Datalog", "false"]}

--- a/examples/async_query.rs
+++ b/examples/async_query.rs
@@ -24,9 +24,9 @@ async fn main() {
     };
 
     let client = Crux::new("localhost", "3000").http_client();
-    let action1 = Action::Put(crux.serialize(), None);
-    let action2 = Action::Put(psql.serialize(), None);
-    let action3 = Action::Put(mysql.serialize(), None);
+    let action1 = Action::Put(edn_rs::to_string(crux), None);
+    let action2 = Action::Put(edn_rs::to_string(psql), None);
+    let action3 = Action::Put(edn_rs::to_string(mysql), None);
 
     let _ = client.tx_log(vec![action1, action2, action3]).await;
 

--- a/examples/async_tx_log.rs
+++ b/examples/async_tx_log.rs
@@ -23,7 +23,8 @@ async fn main() {
     let body = Crux::new("localhost", "3000")
         .http_client()
         .tx_log(vec![action1, action2])
-        .await;
+        .await
+        .unwrap();
 
     println!("body = {:?}", body);
     //  Body = "{:crux.tx/tx-id 7, :crux.tx/tx-time #inst \"2020-07-16T21:50:39.309-00:00\"}"

--- a/examples/async_tx_log.rs
+++ b/examples/async_tx_log.rs
@@ -17,8 +17,8 @@ async fn main() {
         last_name: "Manuel".to_string(),
     };
 
-    let action1 = Action::Put(person1.serialize(), None);
-    let action2 = Action::Put(person2.serialize(), None);
+    let action1 = Action::Put(edn_rs::to_string(person1), None);
+    let action2 = Action::Put(edn_rs::to_string(person2), None);
 
     let body = Crux::new("localhost", "3000")
         .http_client()

--- a/examples/async_tx_logs.rs
+++ b/examples/async_tx_logs.rs
@@ -2,7 +2,11 @@ use transistor::client::Crux;
 
 #[tokio::main]
 async fn main() {
-    let body = Crux::new("localhost", "3000").http_client().tx_logs().await;
+    let body = Crux::new("localhost", "3000")
+        .http_client()
+        .tx_logs()
+        .await
+        .unwrap();
 
     println!("Body = {:#?}", body);
     // Body = TxLogsResponse {

--- a/examples/complex_query.rs
+++ b/examples/complex_query.rs
@@ -38,11 +38,11 @@ fn main() -> Result<(), CruxError> {
     };
 
     let client = Crux::new("localhost", "3000").http_client();
-    let action1 = Action::Put(crux.serialize(), None);
-    let action2 = Action::Put(psql.serialize(), None);
-    let action3 = Action::Put(mysql.serialize(), None);
-    let action4 = Action::Put(cassandra.serialize(), None);
-    let action5 = Action::Put(sqlserver.serialize(), None);
+    let action1 = Action::Put(edn_rs::to_string(crux), None);
+    let action2 = Action::Put(edn_rs::to_string(psql), None);
+    let action3 = Action::Put(edn_rs::to_string(mysql), None);
+    let action4 = Action::Put(edn_rs::to_string(cassandra), None);
+    let action5 = Action::Put(edn_rs::to_string(sqlserver), None);
 
     let _ = client.tx_log(vec![action1, action2, action3, action4, action5])?;
     // Request body for vec![action1, action2]

--- a/examples/entity.rs
+++ b/examples/entity.rs
@@ -9,18 +9,20 @@ fn main() {
         first_name: "Hello".to_string(),
         last_name: "World".to_string(),
     };
-    println!("{:?}", person.clone().serialize());
+    println!("{:?}", edn_rs::to_string(person.clone()));
     //"{ :crux.db/id :hello-entity, :first-name \"Hello\", :last-name \"World\", }"
 
     let client = Crux::new("localhost", "3000").http_client();
-    let put_person = Action::Put(person.clone().serialize(), None);
+    let put_person = Action::Put(edn_rs::to_string(person.clone()), None);
 
     let body = client.tx_log(vec![put_person]).unwrap();
     // "[[:crux.tx/put { :crux.db/id :hello-entity, :first-name \"Hello\", :last-name \"World\", }]]"
     println!("\n Body = {:?}", body);
     //  Body = "{:crux.tx/tx-id 7, :crux.tx/tx-time #inst \"2020-07-16T21:50:39.309-00:00\"}"
 
-    let edn_body = client.entity(person.crux__db___id.serialize()).unwrap();
+    let edn_body = client
+        .entity(edn_rs::to_string(person.crux__db___id))
+        .unwrap();
     println!("\n Edn Body = {:#?}", edn_body.clone());
     // Edn Body = Map(
     //     Map(

--- a/examples/entity.rs
+++ b/examples/entity.rs
@@ -1,5 +1,5 @@
 use transistor::client::Crux;
-use transistor::edn_rs::{ser_struct, Serialize};
+use transistor::edn_rs::{ser_struct, Serialize, Deserialize, EdnError};
 use transistor::types::http::Action;
 use transistor::types::CruxId;
 
@@ -40,7 +40,7 @@ fn main() {
     //     ),
     // )
 
-    println!("\n Person Parsed Response = {:#?}", Person::from(edn_body));
+    println!("\n Person Parsed Response = {:#?}", edn_rs::from_edn::<Person>(&edn_body));
     // Person Parsed Response = Person {
     //     crux__db___id: CruxId(
     //         ":hello-entity",
@@ -60,12 +60,12 @@ ser_struct! {
     }
 }
 
-impl From<edn_rs::Edn> for Person {
-    fn from(edn: edn_rs::Edn) -> Self {
-        Self {
-            crux__db___id: CruxId::new(&edn[":crux.db/id"].to_string()),
-            first_name: edn[":first-name"].to_string(),
-            last_name: edn[":last-name"].to_string(),
-        }
+impl Deserialize for Person {
+    fn deserialize(edn: &edn_rs::Edn) -> Result<Self, EdnError> {
+        Ok(Self {
+            crux__db___id: edn_rs::from_edn(&edn[":crux.db/id"])?,
+            first_name: edn_rs::from_edn(&edn[":first-name"])?,
+            last_name: edn_rs::from_edn(&edn[":last-name"])?,
+        })
     }
 }

--- a/examples/entity_history.rs
+++ b/examples/entity_history.rs
@@ -10,12 +10,14 @@ fn main() {
         last_name: "World".to_string(),
     };
 
-    let put_person = Action::Put(person.clone().serialize(), None);
+    let put_person = Action::Put(edn_rs::to_string(person.clone()), None);
 
     let client = Crux::new("localhost", "3000").http_client();
     let _ = client.tx_log(vec![put_person]).unwrap();
 
-    let tx_body = client.entity_tx(person.crux__db___id.serialize()).unwrap();
+    let tx_body = client
+        .entity_tx(edn_rs::to_string(person.crux__db___id))
+        .unwrap();
 
     let entity_history = client.entity_history(tx_body.db___id.clone(), Order::Asc, true);
     println!("{:?}", entity_history.unwrap());

--- a/examples/entity_tx.rs
+++ b/examples/entity_tx.rs
@@ -9,18 +9,20 @@ fn main() {
         first_name: "Hello".to_string(),
         last_name: "World".to_string(),
     };
-    println!("{:?}", person.clone().serialize());
+    println!("{:?}", edn_rs::to_string(person.clone()));
     //"{ :crux.db/id :hello-entity, :first-name \"Hello\", :last-name \"World\", }"
 
     let client = Crux::new("localhost", "3000").http_client();
-    let put_person = Action::Put(person.clone().serialize(), None);
+    let put_person = Action::Put(edn_rs::to_string(person.clone()), None);
 
     let body = client.tx_log(vec![put_person]).unwrap();
     // "[[:crux.tx/put { :crux.db/id :hello-entity, :first-name \"Hello\", :last-name \"World\", }]]"
     println!("\n Body = {:?}", body);
     //  Body = "{:crux.tx/tx-id 7, :crux.tx/tx-time #inst \"2020-07-16T21:50:39.309-00:00\"}"
 
-    let tx_body = client.entity_tx(person.crux__db___id.serialize()).unwrap();
+    let tx_body = client
+        .entity_tx(edn_rs::to_string(person.crux__db___id))
+        .unwrap();
     println!("\n Tx Body = {:#?}", tx_body);
     // Tx Body = EntityTxResponse {
     //     db___id: "d72ccae848ce3a371bd313865cedc3d20b1478ca",

--- a/examples/evict.rs
+++ b/examples/evict.rs
@@ -9,18 +9,18 @@ fn main() {
         first_name: "Hello".to_string(),
         last_name: "World".to_string(),
     };
-    println!("{:?}", person.clone().serialize());
+    println!("{:?}", edn_rs::to_string(person.clone()));
     //"{ :crux.db/id :hello-evict, :first-name \"Hello\", :last-name \"World\", }"
 
     let client = Crux::new("localhost", "3000").http_client();
 
-    let put_person = Action::Put(person.clone().serialize(), None);
+    let put_person = Action::Put(edn_rs::to_string(person.clone()), None);
     let body = client.tx_log(vec![put_person]).unwrap();
     // "[[:crux.tx/put { :crux.db/id :jorge-3, :first-name \"Michael\", :last-name \"Jorge\", }]]"
     println!("\n Body = {:?}", body);
     //  Body = "{:crux.tx/tx-id 7, :crux.tx/tx-time #inst \"2020-07-16T21:50:39.309-00:00\"}"
 
-    let evict_person = Action::Evict(person.crux__db___id.serialize());
+    let evict_person = Action::Evict(edn_rs::to_string(person.crux__db___id));
     let evict_body = client.tx_log(vec![evict_person]).unwrap();
     println!("\n Evict Body = {:?}", evict_body);
 }

--- a/examples/limit_offset_query.rs
+++ b/examples/limit_offset_query.rs
@@ -38,11 +38,11 @@ fn main() -> Result<(), CruxError> {
     };
 
     let client = Crux::new("localhost", "3000").http_client();
-    let action1 = Action::Put(crux.serialize(), None);
-    let action2 = Action::Put(psql.serialize(), None);
-    let action3 = Action::Put(mysql.serialize(), None);
-    let action4 = Action::Put(cassandra.serialize(), None);
-    let action5 = Action::Put(sqlserver.serialize(), None);
+    let action1 = Action::Put(edn_rs::to_string(crux), None);
+    let action2 = Action::Put(edn_rs::to_string(psql), None);
+    let action3 = Action::Put(edn_rs::to_string(mysql), None);
+    let action4 = Action::Put(edn_rs::to_string(cassandra), None);
+    let action5 = Action::Put(edn_rs::to_string(sqlserver), None);
 
     let _ = client.tx_log(vec![action1, action2, action3, action4, action5])?;
     // Request body for vec![action1, action2]

--- a/examples/match_continue_tx.rs
+++ b/examples/match_continue_tx.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), CruxError> {
     };
 
     let client = Crux::new("localhost", "3000").http_client();
-    let put_action = Action::Put(crux.clone().serialize(), None);
+    let put_action = Action::Put(edn_rs::to_string(crux.clone()), None);
     let _ = client.tx_log(vec![put_action])?;
 
     let query = Query::find(vec!["?d"])?
@@ -23,18 +23,18 @@ fn main() -> Result<(), CruxError> {
 
     let query_response = client.query(query)?;
 
-    let id = CruxId::new(&query_response.iter().next().unwrap()[0]).serialize();
+    let id = edn_rs::to_string(CruxId::new(&query_response.iter().next().unwrap()[0]));
     let edn_body = client.entity(id).unwrap();
     println!("{:?}", edn_body);
     // Map(Map({":crux.db/id": Key(":crux"), ":is-sql": Bool(false), ":name": Str("Crux Datalog")}))
 
     let match_action = Action::Match(
-        CruxId::new(":crux").serialize(),
-        crux.clone().serialize(),
+        edn_rs::to_string(CruxId::new(":crux")),
+        edn_rs::to_string(crux.clone()),
         None,
     );
     crux.name = "banana".to_string();
-    let put_action = Action::Put(crux.clone().serialize(), None);
+    let put_action = Action::Put(edn_rs::to_string(crux.clone()), None);
     let result = client.tx_log(vec![match_action, put_action])?;
 
     println!("{:?}", result);
@@ -46,7 +46,7 @@ fn main() -> Result<(), CruxError> {
 
     let query_response = client.query(query)?;
 
-    let id = CruxId::new(&query_response.iter().next().unwrap()[0]).serialize();
+    let id = edn_rs::to_string(CruxId::new(&query_response.iter().next().unwrap()[0]));
     let edn_body = client.entity(id).unwrap();
     println!("{:?}", edn_body);
     // Map(Map({":crux.db/id": Key(":crux"), ":is-sql": Bool(false), ":name": Str("banana")}))

--- a/examples/match_no_continue_tx.rs
+++ b/examples/match_no_continue_tx.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), CruxError> {
     };
 
     let client = Crux::new("localhost", "3000").http_client();
-    let put_action = Action::Put(crux.clone().serialize(), None);
+    let put_action = Action::Put(edn_rs::to_string(crux.clone()), None);
     let _ = client.tx_log(vec![put_action])?;
 
     let query = Query::find(vec!["?d"])?
@@ -23,18 +23,18 @@ fn main() -> Result<(), CruxError> {
 
     let query_response = client.query(query)?;
 
-    let id = CruxId::new(&query_response.iter().next().unwrap()[0]).serialize();
+    let id = edn_rs::to_string(CruxId::new(&query_response.iter().next().unwrap()[0]));
     let edn_body = client.entity(id).unwrap();
     println!("{:?}", edn_body);
     // Map(Map({":crux.db/id": Key(":crux"), ":is-sql": Bool(false), ":name": Str("Crux Datalog")}))
 
     crux.name = "banana".to_string();
     let match_action = Action::Match(
-        CruxId::new(":crux").serialize(),
-        crux.clone().serialize(),
+        edn_rs::to_string(CruxId::new(":crux")),
+        edn_rs::to_string(crux.clone()),
         None,
     );
-    let put_action = Action::Put(crux.clone().serialize(), None);
+    let put_action = Action::Put(edn_rs::to_string(crux.clone()), None);
     let result = client.tx_log(vec![match_action, put_action])?;
 
     println!("{:?}", result);
@@ -46,7 +46,7 @@ fn main() -> Result<(), CruxError> {
 
     let query_response = client.query(query)?;
 
-    let id = CruxId::new(&query_response.iter().next().unwrap()[0]).serialize();
+    let id = edn_rs::to_string(CruxId::new(&query_response.iter().next().unwrap()[0]));
     let edn_body = client.entity(id).unwrap();
     println!("{:?}", edn_body);
     // Map(Map({":crux.db/id": Key(":crux"), ":is-sql": Bool(false), ":name": Str("Crux Datalog")}))

--- a/examples/simple_query.rs
+++ b/examples/simple_query.rs
@@ -24,17 +24,17 @@ fn main() -> Result<(), CruxError> {
         name: "MySQL".to_string(),
         is_sql: true,
     };
-    println!("{:?}", crux.clone().serialize());
-    println!("{:?}", psql.clone().serialize());
-    println!("{:?}", mysql.clone().serialize());
+    println!("{:?}", edn_rs::to_string(crux.clone()));
+    println!("{:?}", edn_rs::to_string(psql.clone()));
+    println!("{:?}", edn_rs::to_string(mysql.clone()));
     // "{ :crux.db/id :crux, :name \"Crux Datalog\", :is-sql false, }"
     // "{ :crux.db/id :postgres, :name \"Postgres\", :is-sql true, }"
     // "{ :crux.db/id :mysql, :name \"MySQL\", :is-sql true, }"
 
     let client = Crux::new("localhost", "3000").http_client();
-    let action1 = Action::Put(crux.serialize(), None);
-    let action2 = Action::Put(psql.serialize(), None);
-    let action3 = Action::Put(mysql.serialize(), None);
+    let action1 = Action::Put(edn_rs::to_string(crux), None);
+    let action2 = Action::Put(edn_rs::to_string(psql), None);
+    let action3 = Action::Put(edn_rs::to_string(mysql), None);
 
     let _ = client.tx_log(vec![action1, action2, action3])?;
     // Request body for vec![action1, action2]

--- a/examples/tx_log.rs
+++ b/examples/tx_log.rs
@@ -15,13 +15,13 @@ fn main() {
         first_name: "Diego".to_string(),
         last_name: "Manuel".to_string(),
     };
-    println!("{:?}", person1.clone().serialize());
+    println!("{:?}", edn_rs::to_string(person1.clone()));
     //"{ :crux.db/id :jorge-3, :first-name \"Michael\", :last-name \"Jorge\", }"
-    println!("{:?}", person2.clone().serialize());
+    println!("{:?}", edn_rs::to_string(person2.clone()));
     //"{ :crux.db/id :manuel-1, :first-name \"Diego\", :last-name \"Manuel\", }"
 
-    let action1 = Action::Put(person1.serialize(), None);
-    let action2 = Action::Put(person2.serialize(), None);
+    let action1 = Action::Put(edn_rs::to_string(person1), None);
+    let action2 = Action::Put(edn_rs::to_string(person2), None);
 
     let body = Crux::new("localhost", "3000")
         .http_client()

--- a/src/http.rs
+++ b/src/http.rs
@@ -9,7 +9,7 @@ use crate::types::{
     response::{EntityHistoryResponse, EntityTxResponse, TxLogResponse, TxLogsResponse},
 };
 use chrono::prelude::*;
-use edn_rs::{edn, Edn, Map, Serialize};
+use edn_rs::{edn, Edn, Map};
 #[cfg(not(feature = "async"))]
 use reqwest::blocking;
 use reqwest::header::HeaderMap;
@@ -37,7 +37,7 @@ impl HttpClient {
     pub fn tx_log(&self, actions: Vec<Action>) -> Result<TxLogResponse, CruxError> {
         let actions_str = actions
             .into_iter()
-            .map(|edn| edn.serialize())
+            .map(edn_rs::to_string)
             .collect::<Vec<String>>()
             .join(", ");
         let mut s = String::new();
@@ -180,7 +180,7 @@ impl HttpClient {
             "{}/entity-history/{}?sort-order={}&with-docs={}",
             self.uri,
             hash,
-            order.serialize(),
+            edn_rs::to_string(order),
             with_docs
         );
         let resp = self
@@ -207,9 +207,9 @@ impl HttpClient {
             "{}/entity-history/{}?sort-order={}&with-docs={}{}",
             self.uri,
             hash,
-            order.serialize(),
+            edn_rs::to_string(order),
             with_docs,
-            time.serialize().replace("[", "").replace("]", ""),
+            edn_rs::to_string(time).replace("[", "").replace("]", ""),
         );
 
         let resp = self
@@ -229,7 +229,7 @@ impl HttpClient {
             .client
             .post(&format!("{}/query", self.uri))
             .headers(self.headers.clone())
-            .body(query.serialize())
+            .body(edn_rs::to_string(query))
             .send()?
             .text()?;
 
@@ -244,7 +244,7 @@ impl HttpClient {
     pub async fn tx_log(&self, actions: Vec<Action>) -> Result<TxLogResponse, CruxError> {
         let actions_str = actions
             .into_iter()
-            .map(|edn| edn.serialize())
+            .map(edn_rs::to_string)
             .collect::<Vec<String>>()
             .join(", ");
         let mut s = String::new();
@@ -387,7 +387,7 @@ impl HttpClient {
             "{}/entity-history/{}?sort-order={}&with-docs={}",
             self.uri,
             hash,
-            order.serialize(),
+            edn_rs::to_string(order),
             with_docs
         );
         let resp = self
@@ -413,9 +413,9 @@ impl HttpClient {
             "{}/entity-history/{}?sort-order={}&with-docs={}{}",
             self.uri,
             hash,
-            order.serialize(),
+            edn_rs::to_string(order),
             with_docs,
-            time.serialize().replace("[", "").replace("]", ""),
+            edn_rs::to_string(time).replace("[", "").replace("]", ""),
         );
 
         let resp = self
@@ -435,7 +435,7 @@ impl HttpClient {
             .client
             .post(&format!("{}/query", self.uri))
             .headers(self.headers.clone())
-            .body(query.serialize())
+            .body(edn_rs::to_string(query))
             .send()
             .await?
             .text()
@@ -522,8 +522,8 @@ mod http {
             last_name: "Manuel".to_string(),
         };
 
-        let action1 = Action::Put(person1.serialize(), None);
-        let action2 = Action::Put(person2.serialize(), None);
+        let action1 = Action::Put(edn_rs::to_string(person1), None);
+        let action2 = Action::Put(edn_rs::to_string(person2), None);
 
         let response = Crux::new("localhost", "4000")
             .http_client()

--- a/src/types/http.rs
+++ b/src/types/http.rs
@@ -136,7 +136,7 @@ impl VecSer for Vec<TimeHistory> {
             String::new()
         } else {
             self.into_iter()
-                .map(|e| e.serialize())
+                .map(edn_rs::to_string)
                 .collect::<Vec<String>>()
                 .join("")
         }

--- a/src/types/query.rs
+++ b/src/types/query.rs
@@ -190,19 +190,19 @@ impl Query {
 impl Serialize for Query {
     fn serialize(self) -> String {
         let mut q = String::from("{:query\n {");
-        q.push_str(&self.find.serialize());
-        q.push_str(&self.where_.unwrap().serialize());
+        q.push_str(&edn_rs::to_string(self.find));
+        q.push_str(&edn_rs::to_string(self.where_.unwrap()));
         if self.args.is_some() {
-            q.push_str(&self.args.unwrap().serialize());
+            q.push_str(&edn_rs::to_string(self.args.unwrap()));
         }
         if self.order_by.is_some() {
-            q.push_str(&self.order_by.unwrap().serialize());
+            q.push_str(&edn_rs::to_string(self.order_by.unwrap()));
         }
         if self.limit.is_some() {
-            q.push_str(&self.limit.unwrap().serialize());
+            q.push_str(&edn_rs::to_string(self.limit.unwrap()));
         }
         if self.offset.is_some() {
-            q.push_str(&self.offset.unwrap().serialize());
+            q.push_str(&edn_rs::to_string(self.offset.unwrap()));
         }
         if self.full_results == true {
             q.push_str(" :full-results? true\n")
@@ -303,7 +303,6 @@ fn args_key_bset(args: &Vec<&str>) -> BTreeSet<String> {
 mod test {
     use super::Query;
     use crate::client::Crux;
-    use edn_rs::Serialize;
 
     #[test]
     fn query_with_find_and_where() {
@@ -315,7 +314,7 @@ mod test {
             .unwrap()
             .build();
 
-        assert_eq!(q.unwrap().serialize(), expected);
+        assert_eq!(edn_rs::to_string(q.unwrap()), expected);
     }
 
     #[test]
@@ -339,7 +338,7 @@ mod test {
             .unwrap()
             .build();
 
-        assert_eq!(q.unwrap().serialize(), expected);
+        assert_eq!(edn_rs::to_string(q.unwrap()), expected);
     }
 
     #[test]
@@ -354,7 +353,7 @@ mod test {
             .unwrap()
             .build();
 
-        assert_eq!(q.unwrap().serialize(), expected);
+        assert_eq!(edn_rs::to_string(q.unwrap()), expected);
     }
 
     #[test]
@@ -369,7 +368,7 @@ mod test {
             .offset(10)
             .build();
 
-        assert_eq!(q.unwrap().serialize(), expected);
+        assert_eq!(edn_rs::to_string(q.unwrap()), expected);
     }
 
     #[test]
@@ -388,7 +387,7 @@ mod test {
             .offset(10)
             .build();
 
-        assert_eq!(q.unwrap().serialize(), expected);
+        assert_eq!(edn_rs::to_string(q.unwrap()), expected);
     }
 
     #[test]
@@ -464,6 +463,6 @@ mod test {
             .with_full_results()
             .build();
 
-        assert_eq!(q.unwrap().serialize(), expected);
+        assert_eq!(edn_rs::to_string(q.unwrap()), expected);
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -185,8 +185,8 @@ mod integration {
         };
 
         vec![
-            Action::Put(person1.serialize(), None),
-            Action::Put(person2.serialize(), None),
+            Action::Put(edn_rs::to_string(person1), None),
+            Action::Put(edn_rs::to_string(person2), None),
         ]
     }
 


### PR DESCRIPTION
- Replace `.serialize` to `edn_rs::to_string`
- Use unwrap in async examples to fail tests correctly
- Replace missing `From<Edn>` to `Deserialize`
- Bump `edn-rs` to `0.16.2`
