### PR TITLE
Enforce Actions type in TxLog

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,11 +266,11 @@ let is_sql = client.query(query_is_sql.unwrap()).unwrap();
 * `new` static method to instantiate struct `Actions`.
 * `append_put<T: Serialize>(action: T)` appends a [`Put`](https://opencrux.com/reference/transactions.html#put) to `Actions` with no `valid-time`. `Put` writes a document.
 * `append_put_timed<T: Serialize>(action: T, date: DateTime<FixedOffset>)` appends a [`Put`](https://opencrux.com/reference/transactions.html#put) to `Actions` with `valid-time`.
-* `append_delete(id: crate::types::CruxId)` appends a [`Delete`](https://opencrux.com/reference/transactions.html#delete) to `Actions` with no `valid-time`. Deletes the specific document at last `valid-time`.
-* `append_delete_timed(id: crate::types::CruxId, date: DateTime<FixedOffset>)` appends a [`Delete`](https://opencrux.com/reference/transactions.html#delete)  to `Actions` with `valid-time`. Deletes the specific document at the given `valid-time`.
-* `append_evict(id: crate::types::CruxId)` appends a [`Evict`](https://opencrux.com/reference/transactions.html#evict) to `Actions`. Evicts a document entirely, including all historical versions (receives only the ID to evict).
-* `append_match_doc<T: Serialize>(id: crate::types::CruxId, action: T)` appends a [`Match`](https://opencrux.com/reference/transactions.html#match) to `Actions` with no `valid-time`. Matches the current state of an entity, if the state doesn't match the provided document, the transaction will not continue.
-* `append_match_doc_timed<T: Serialize>(id: crate::types::CruxId, action: T, date: DateTime<FixedOffset>)` appends a [`Match`](https://opencrux.com/reference/transactions.html#match) to `Actions` with `valid-time`.
+* `append_delete(id: CruxId)` appends a [`Delete`](https://opencrux.com/reference/transactions.html#delete) to `Actions` with no `valid-time`. Deletes the specific document at last `valid-time`.
+* `append_delete_timed(id: CruxId, date: DateTime<FixedOffset>)` appends a [`Delete`](https://opencrux.com/reference/transactions.html#delete)  to `Actions` with `valid-time`. Deletes the specific document at the given `valid-time`.
+* `append_evict(id: CruxId)` appends a [`Evict`](https://opencrux.com/reference/transactions.html#evict) to `Actions`. Evicts a document entirely, including all historical versions (receives only the ID to evict).
+* `append_match_doc<T: Serialize>(id: CruxId, action: T)` appends a [`Match`](https://opencrux.com/reference/transactions.html#match) to `Actions` with no `valid-time`. Matches the current state of an entity, if the state doesn't match the provided document, the transaction will not continue.
+* `append_match_doc_timed<T: Serialize>(id: CruxId, action: T, date: DateTime<FixedOffset>)` appends a [`Match`](https://opencrux.com/reference/transactions.html#match) to `Actions` with `valid-time`.
 * `build` generates the `Vec<Action>` from `Actions`
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ let body = client.state().unwrap();
 // }
 ```
 
-* [`tx_log`](https://docs.rs/transistor/1.3.11/transistor/http/struct.HttpClient.html#method.tx_log) requests endpoint [`/tx-log`](https://opencrux.com/reference/http.html#tx-log-post) via `POST`. A Vector of `Action` is expected as argument. The "write" endpoint, to post transactions.
+* [`tx_log`](https://docs.rs/transistor/1.3.11/transistor/http/struct.HttpClient.html#method.tx_log) requests endpoint [`/tx-log`](https://opencrux.com/reference/http.html#tx-log-post) via `POST`. `Actions` is expected as argument. The "write" endpoint, to post transactions.
 ```rust
-use transistor::http::{Action};
+use transistor::http::{Actions};
 use transistor::client::Crux;
 use transistor::types::{CruxId};
 
@@ -92,11 +92,11 @@ let person2 = Person {
     ..
 };
 
-// put expects a `T: Serialize`
-let action1 = Action::put(person1);
-let action2 = Action::put(person2);
+let actions = Actions::new()
+    .append_put(person1)
+    .append_put(person2);
 
-let body = client.tx_log(vec![action1, action2]).unwrap();
+let body = client.tx_log(actions).unwrap();
 // {:crux.tx/tx-id 7, :crux.tx/tx-time #inst \"2020-07-16T21:50:39.309-00:00\"}
 ```
 
@@ -260,22 +260,17 @@ let is_sql = client.query(query_is_sql.unwrap()).unwrap();
 // {[":mysql", "MySQL"], [":postgres", "Postgres"]} BTreeSet
 ```
 
-[`Action`](https://docs.rs/transistor/1.3.11/transistor/http/enum.Action.html) is an enum with a set of options to use in association with the function `tx_log`:
-* [`Put`](https://opencrux.com/reference/transactions.html#put) - Write a version of a document
-* [`Delete`](https://opencrux.com/reference/transactions.html#delete) - Deletes the specific document at a given valid time
-* [`Evict`](https://opencrux.com/reference/transactions.html#evict) - Evicts a document entirely, including all historical versions (receives only the ID to evict)
-* [`Match`](https://opencrux.com/reference/transactions.html#match) - Matches the current state of an entity, if the state doesn't match the provided document, the transaction will not continue
-* To create a single `Action` use the static methods for `put`, `evict`, `delete`, `match_doc`. To add a `:valid-date` to your `Action` call builder function `with_valid_date`, like `Action::put(person).with_valid_date(timed)`.
+### Transisitor's Structs and Enums
 
 [`Actions`](https://docs.rs/transistor/1.3.11/transistor/http/enum.Actions.html) is a builder struct to help you create a `Vec<Action>` for `tx_log`. Available functions are:
 * `new` static method to instantiate struct `Actions`.
-* `append_put<T: Serialize>(action: T)` appends an `Action::Put` to `Actions` with no `valid-time`.
-* `append_put_timed<T: Serialize>(action: T, date: DateTime<FixedOffset>)` appends an `Action::Put` to `Actions` with `valid-time`.
-* `append_delete(id: crate::types::CruxId)` appends an `Action::Delete` to `Actions` with no `valid-time`.
-* `append_delete_timed(id: crate::types::CruxId, date: DateTime<FixedOffset>)` appends an `Action::Delete` to `Actions` with `valid-time`.
-* `append_evict(id: crate::types::CruxId)` appends an `Action::Evict` to `Actions`.
-* `append_match_doc<T: Serialize>(id: crate::types::CruxId, action: T)` appends an `Action::Match` to `Actions` with no `valid-time`.
-* `append_match_doc_timed<T: Serialize>(id: crate::types::CruxId, action: T, date: DateTime<FixedOffset>)` appends an `Action::Match` to `Actions` with `valid-time`.
+* `append_put<T: Serialize>(action: T)` appends a [`Put`](https://opencrux.com/reference/transactions.html#put) to `Actions` with no `valid-time`. `Put` writes a document.
+* `append_put_timed<T: Serialize>(action: T, date: DateTime<FixedOffset>)` appends a [`Put`](https://opencrux.com/reference/transactions.html#put) to `Actions` with `valid-time`.
+* `append_delete(id: crate::types::CruxId)` appends a [`Delete`](https://opencrux.com/reference/transactions.html#delete) to `Actions` with no `valid-time`. Deletes the specific document at last `valid-time`.
+* `append_delete_timed(id: crate::types::CruxId, date: DateTime<FixedOffset>)` appends a [`Delete`](https://opencrux.com/reference/transactions.html#delete)  to `Actions` with `valid-time`. Deletes the specific document at the given `valid-time`.
+* `append_evict(id: crate::types::CruxId)` appends a [`Evict`](https://opencrux.com/reference/transactions.html#evict) to `Actions`. Evicts a document entirely, including all historical versions (receives only the ID to evict).
+* `append_match_doc<T: Serialize>(id: crate::types::CruxId, action: T)` appends a [`Match`](https://opencrux.com/reference/transactions.html#match) to `Actions` with no `valid-time`. Matches the current state of an entity, if the state doesn't match the provided document, the transaction will not continue.
+* `append_match_doc_timed<T: Serialize>(id: crate::types::CruxId, action: T, date: DateTime<FixedOffset>)` appends a [`Match`](https://opencrux.com/reference/transactions.html#match) to `Actions` with `valid-time`.
 * `build` generates the `Vec<Action>` from `Actions`
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -422,6 +422,54 @@ ser_struct! {
 
 ```
 
+Also, struct `Actions` can be tested with feature `mock` by using enum `ActionMock` due to the implementation of `impl PartialEq<Vec<ActionMock>> for Actions`. A demo example can be:
+
+```rust
+use transistor::types::http::{Actions, ActionMock};
+
+fn test_actions_eq_actions_mock() {
+    let actions = test_actions();
+    let mock = test_action_mock();
+
+    assert_eq!(actions, mock);
+}
+
+fn test_action_mock() -> Vec<ActionMock> {
+    let person1 = Person {
+        crux__db___id: CruxId::new("jorge-3"),
+        first_name: "Michael".to_string(),
+        last_name: "Jorge".to_string(),
+    };
+
+    let person2 = Person {
+        crux__db___id: CruxId::new("manuel-1"),
+        first_name: "Diego".to_string(),
+        last_name: "Manuel".to_string(),
+    };
+
+    vec![
+        ActionMock::Put(person1.clone().serialize(), None),
+        ActionMock::Put(person2.serialize(), None),
+        ActionMock::Delete(person1.crux__db___id.serialize(), None),
+    ]
+}
+
+fn test_actions() -> Actions {
+    let person1 = Person {
+        crux__db___id: CruxId::new("jorge-3"),
+        first_name: "Michael".to_string(),
+        last_name: "Jorge".to_string(),
+    };
+
+    let person2 = Person {
+        crux__db___id: CruxId::new("manuel-1"),
+        first_name: "Diego".to_string(),
+        last_name: "Manuel".to_string(),
+    };
+    Actions::new().append_put(person1.clone()).append_put(person2).append_delete(person1.crux__db___id)
+}
+```
+
 ### Async support
 
 **Async feature is still in BETA** as it depends heavily on `unwraps`.

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ let is_sql = client.query(query_is_sql.unwrap()).unwrap();
 * `append_put_timed<T: Serialize>(action: T, date: DateTime<FixedOffset>)` appends a [`Put`](https://opencrux.com/reference/transactions.html#put) to `Actions` with `valid-time`.
 * `append_delete(id: CruxId)` appends a [`Delete`](https://opencrux.com/reference/transactions.html#delete) to `Actions` with no `valid-time`. Deletes the specific document at last `valid-time`.
 * `append_delete_timed(id: CruxId, date: DateTime<FixedOffset>)` appends a [`Delete`](https://opencrux.com/reference/transactions.html#delete)  to `Actions` with `valid-time`. Deletes the specific document at the given `valid-time`.
-* `append_evict(id: CruxId)` appends a [`Evict`](https://opencrux.com/reference/transactions.html#evict) to `Actions`. Evicts a document entirely, including all historical versions (receives only the ID to evict).
+* `append_evict(id: CruxId)` appends an [`Evict`](https://opencrux.com/reference/transactions.html#evict) to `Actions`. Evicts a document entirely, including all historical versions (receives only the ID to evict).
 * `append_match_doc<T: Serialize>(id: CruxId, action: T)` appends a [`Match`](https://opencrux.com/reference/transactions.html#match) to `Actions` with no `valid-time`. Matches the current state of an entity, if the state doesn't match the provided document, the transaction will not continue.
 * `append_match_doc_timed<T: Serialize>(id: CruxId, action: T, date: DateTime<FixedOffset>)` appends a [`Match`](https://opencrux.com/reference/transactions.html#match) to `Actions` with `valid-time`.
 * `build` generates the `Vec<Action>` from `Actions`
@@ -448,9 +448,9 @@ fn test_action_mock() -> Vec<ActionMock> {
     };
 
     vec![
-        ActionMock::Put(person1.clone().serialize(), None),
-        ActionMock::Put(person2.serialize(), None),
-        ActionMock::Delete(person1.crux__db___id.serialize(), None),
+        ActionMock::Put(edn_rs::to_string(person1.clone()), None),
+        ActionMock::Put(edn_rs::to_string(person2), None),
+        ActionMock::Delete(edn_rs::to_string(person1.crux__db___id), None),
     ]
 }
 

--- a/examples/async_entity_history_timed.rs
+++ b/examples/async_entity_history_timed.rs
@@ -33,8 +33,7 @@ async fn main() {
 
     let actions = Actions::new()
         .append_put_timed(person1, timed)
-        .append_put_timed(person2, timed)
-        .build();
+        .append_put_timed(person2, timed);
 
     let _ = Crux::new("localhost", "3000")
         .http_client()

--- a/examples/async_entity_history_timed.rs
+++ b/examples/async_entity_history_timed.rs
@@ -32,8 +32,8 @@ async fn main() {
     let time_history = TimeHistory::ValidTime(Some(start_timed), Some(end_timed));
 
     let actions = Actions::new()
-        .append_put_timed(person1, timed)
-        .append_put_timed(person2, timed);
+        .append_put_timed(person1.clone(), timed.clone())
+        .append_put_timed(person2, timed.clone());
 
     let _ = Crux::new("localhost", "3000")
         .http_client()

--- a/examples/async_entity_history_timed.rs
+++ b/examples/async_entity_history_timed.rs
@@ -32,8 +32,8 @@ async fn main() {
     let time_history = TimeHistory::ValidTime(Some(start_timed), Some(end_timed));
 
     let actions = Actions::new()
-        .append_put_timed(person1.clone(), timed.clone())
-        .append_put_timed(person2, timed.clone());
+        .append_put_timed(person1.clone(), timed)
+        .append_put_timed(person2, timed);
 
     let _ = Crux::new("localhost", "3000")
         .http_client()

--- a/examples/async_entity_timed.rs
+++ b/examples/async_entity_timed.rs
@@ -24,7 +24,7 @@ async fn main() {
         .unwrap();
 
     let actions = Actions::new()
-        .append_put_timed(person1, timed)
+        .append_put_timed(person1.clone(), timed)
         .append_put_timed(person2, timed);
 
     let _ = Crux::new("localhost", "3000")

--- a/examples/async_entity_timed.rs
+++ b/examples/async_entity_timed.rs
@@ -25,8 +25,7 @@ async fn main() {
 
     let actions = Actions::new()
         .append_put_timed(person1, timed)
-        .append_put_timed(person2, timed)
-        .build();
+        .append_put_timed(person2, timed);
 
     let _ = Crux::new("localhost", "3000")
         .http_client()

--- a/examples/async_entity_tx_timed.rs
+++ b/examples/async_entity_tx_timed.rs
@@ -24,8 +24,8 @@ async fn main() {
         .unwrap();
 
     let actions = Actions::new()
-        .append_put_timed(person1, timed)
-        .append_put_timed(person2, timed);
+        .append_put_timed(person1.clone(), timed.clone())
+        .append_put_timed(person2, timed.clone());
 
     let _ = Crux::new("localhost", "3000")
         .http_client()

--- a/examples/async_entity_tx_timed.rs
+++ b/examples/async_entity_tx_timed.rs
@@ -25,8 +25,7 @@ async fn main() {
 
     let actions = Actions::new()
         .append_put_timed(person1, timed)
-        .append_put_timed(person2, timed)
-        .build();
+        .append_put_timed(person2, timed);
 
     let _ = Crux::new("localhost", "3000")
         .http_client()

--- a/examples/async_query.rs
+++ b/examples/async_query.rs
@@ -1,6 +1,6 @@
 use transistor::client::Crux;
 use transistor::edn_rs::{ser_struct, Serialize};
-use transistor::types::http::Action;
+use transistor::types::http::Actions;
 use transistor::types::{query::Query, CruxId};
 
 #[tokio::main]
@@ -24,14 +24,12 @@ async fn main() {
     };
 
     let client = Crux::new("localhost", "3000").http_client();
-    let action1 = Action::put(crux);
-    let action2 = Action::put(psql);
-    let action3 = Action::put(mysql);
+    let actions = Actions::new()
+        .append_put(crux)
+        .append_put(psql)
+        .append_put(mysql);
 
-    let _ = client
-        .tx_log(vec![action1, action2, action3])
-        .await
-        .unwrap();
+    let _ = client.tx_log(actions).await.unwrap();
 
     let query_is_sql = Query::find(vec!["?p1", "?n"])
         .unwrap()

--- a/examples/async_tx_log.rs
+++ b/examples/async_tx_log.rs
@@ -1,6 +1,6 @@
 use transistor::client::Crux;
 use transistor::edn_rs::{ser_struct, Serialize};
-use transistor::types::http::Action;
+use transistor::types::http::Actions;
 use transistor::types::CruxId;
 
 #[tokio::main]
@@ -17,12 +17,11 @@ async fn main() {
         last_name: "Manuel".to_string(),
     };
 
-    let action1 = Action::put(person1);
-    let action2 = Action::put(person2);
+    let actions = Actions::new().append_put(person1).append_put(person2);
 
     let body = Crux::new("localhost", "3000")
         .http_client()
-        .tx_log(vec![action1, action2])
+        .tx_log(actions)
         .await
         .unwrap();
 

--- a/examples/complex_query.rs
+++ b/examples/complex_query.rs
@@ -43,8 +43,7 @@ fn main() -> Result<(), CruxError> {
         .append_put(psql)
         .append_put(mysql)
         .append_put(cassandra)
-        .append_put(sqlserver)
-        .build();
+        .append_put(sqlserver);
 
     let _ = client.tx_log(actions)?;
     // Request body for vec![action1, action2]

--- a/examples/entity.rs
+++ b/examples/entity.rs
@@ -1,6 +1,6 @@
 use transistor::client::Crux;
 use transistor::edn_rs::{ser_struct, Deserialize, EdnError, Serialize};
-use transistor::types::http::Action;
+use transistor::types::http::Actions;
 use transistor::types::CruxId;
 
 fn main() {
@@ -13,9 +13,9 @@ fn main() {
     //"{ :crux.db/id :hello-entity, :first-name \"Hello\", :last-name \"World\", }"
 
     let client = Crux::new("localhost", "3000").http_client();
-    let put_person = Action::put(person.clone());
+    let put_person = Actions::new().append_put(person.clone());
 
-    let body = client.tx_log(vec![put_person]).unwrap();
+    let body = client.tx_log(put_person).unwrap();
     // "[[:crux.tx/put { :crux.db/id :hello-entity, :first-name \"Hello\", :last-name \"World\", }]]"
     println!("\n Body = {:?}", body);
     //  Body = "{:crux.tx/tx-id 7, :crux.tx/tx-time #inst \"2020-07-16T21:50:39.309-00:00\"}"

--- a/examples/entity_history.rs
+++ b/examples/entity_history.rs
@@ -1,6 +1,6 @@
 use transistor::client::Crux;
 use transistor::edn_rs::{ser_struct, Serialize};
-use transistor::types::http::{Action, Order};
+use transistor::types::http::{Actions, Order};
 use transistor::types::CruxId;
 
 fn main() {
@@ -10,10 +10,10 @@ fn main() {
         last_name: "World".to_string(),
     };
 
-    let put_person = Action::put(person.clone());
+    let put_person = Actions::new().append_put(person.clone());
 
     let client = Crux::new("localhost", "3000").http_client();
-    let _ = client.tx_log(vec![put_person]).unwrap();
+    let _ = client.tx_log(put_person).unwrap();
 
     let tx_body = client.entity_tx(person.crux__db___id).unwrap();
 

--- a/examples/entity_tx.rs
+++ b/examples/entity_tx.rs
@@ -1,6 +1,6 @@
 use transistor::client::Crux;
 use transistor::edn_rs::{ser_struct, Serialize};
-use transistor::types::http::Action;
+use transistor::types::http::Actions;
 use transistor::types::CruxId;
 
 fn main() {
@@ -13,9 +13,9 @@ fn main() {
     //"{ :crux.db/id :hello-entity, :first-name \"Hello\", :last-name \"World\", }"
 
     let client = Crux::new("localhost", "3000").http_client();
-    let put_person = Action::put(person.clone());
+    let put_person = Actions::new().append_put(person.clone());
 
-    let body = client.tx_log(vec![put_person]).unwrap();
+    let body = client.tx_log(put_person).unwrap();
     // "[[:crux.tx/put { :crux.db/id :hello-entity, :first-name \"Hello\", :last-name \"World\", }]]"
     println!("\n Body = {:?}", body);
     //  Body = "{:crux.tx/tx-id 7, :crux.tx/tx-time #inst \"2020-07-16T21:50:39.309-00:00\"}"

--- a/examples/evict.rs
+++ b/examples/evict.rs
@@ -1,6 +1,6 @@
 use transistor::client::Crux;
 use transistor::edn_rs::{ser_struct, Serialize};
-use transistor::types::http::Action;
+use transistor::types::http::Actions;
 use transistor::types::CruxId;
 
 fn main() {
@@ -14,14 +14,14 @@ fn main() {
 
     let client = Crux::new("localhost", "3000").http_client();
 
-    let put_person = Action::put(person.clone());
-    let body = client.tx_log(vec![put_person]).unwrap();
+    let actions = Actions::new().append_put(person.clone());
+    let body = client.tx_log(actions).unwrap();
     // "[[:crux.tx/put { :crux.db/id :jorge-3, :first-name \"Michael\", :last-name \"Jorge\", }]]"
     println!("\n Body = {:?}", body);
     //  Body = "{:crux.tx/tx-id 7, :crux.tx/tx-time #inst \"2020-07-16T21:50:39.309-00:00\"}"
 
-    let evict_person = Action::evict(person.crux__db___id);
-    let evict_body = client.tx_log(vec![evict_person]).unwrap();
+    let actions = Actions::new().append_evict(person.crux__db___id);
+    let evict_body = client.tx_log(actions).unwrap();
     println!("\n Evict Body = {:?}", evict_body);
 }
 

--- a/examples/limit_offset_query.rs
+++ b/examples/limit_offset_query.rs
@@ -1,6 +1,6 @@
 use transistor::client::Crux;
 use transistor::edn_rs::{ser_struct, Serialize};
-use transistor::types::http::Action;
+use transistor::types::http::Actions;
 use transistor::types::{
     error::CruxError,
     {query::Query, CruxId},
@@ -38,13 +38,14 @@ fn main() -> Result<(), CruxError> {
     };
 
     let client = Crux::new("localhost", "3000").http_client();
-    let action1 = Action::put(crux);
-    let action2 = Action::put(psql);
-    let action3 = Action::put(mysql);
-    let action4 = Action::put(cassandra);
-    let action5 = Action::put(sqlserver);
+    let actions = Actions::new()
+        .append_put(crux)
+        .append_put(psql)
+        .append_put(mysql)
+        .append_put(cassandra)
+        .append_put(sqlserver);
 
-    let _ = client.tx_log(vec![action1, action2, action3, action4, action5])?;
+    let _ = client.tx_log(actions)?;
     // Request body for vec![action1, action2]
     // "[[:crux.tx/put { :crux.db/id :crux, :name \"Crux Datalog\", :is-sql false, }],
     //   [:crux.tx/put { :crux.db/id :mysql, :name \"MySQL\", :is-sql true, }],

--- a/examples/match_continue_tx.rs
+++ b/examples/match_continue_tx.rs
@@ -1,21 +1,22 @@
 use transistor::client::Crux;
 use transistor::edn_rs::{ser_struct, Serialize};
-use transistor::types::http::Action;
+use transistor::types::http::Actions;
 use transistor::types::{
     error::CruxError,
     {query::Query, CruxId},
 };
 
 fn main() -> Result<(), CruxError> {
-    let mut crux = Database {
+    let crux = Database {
         crux__db___id: CruxId::new("crux"),
         name: "Crux Datalog".to_string(),
         is_sql: false,
     };
 
     let client = Crux::new("localhost", "3000").http_client();
-    let put_action = Action::put(crux.clone());
-    let _ = client.tx_log(vec![put_action])?;
+    let actions = Actions::new().append_put(crux.clone());
+
+    let _ = client.tx_log(actions)?;
 
     let query = Query::find(vec!["?d"])?
         .where_clause(vec!["?d :is-sql false"])?
@@ -28,10 +29,10 @@ fn main() -> Result<(), CruxError> {
     println!("{:?}", edn_body);
     // Map(Map({":crux.db/id": Key(":crux"), ":is-sql": Bool(false), ":name": Str("Crux Datalog")}))
 
-    let match_action = Action::match_doc(CruxId::new(":crux"), crux.clone());
-    crux.name = "banana".to_string();
-    let put_action = Action::put(crux.clone());
-    let result = client.tx_log(vec![match_action, put_action])?;
+    let actions = Actions::new()
+        .append_match_doc(CruxId::new(":crux"), crux.clone())
+        .append_put(crux.rename("banana"));
+    let result = client.tx_log(actions)?;
 
     println!("{:?}", result);
     // TxLogResponse { tx___tx_id: 54, tx___tx_time: "2020-08-09T03:54:20.730-00:00", tx__event___tx_events: None }
@@ -57,5 +58,12 @@ ser_struct! {
         crux__db___id: CruxId,
         name: String,
         is_sql: bool
+    }
+}
+
+impl Database {
+    fn rename(mut self, name: &str) -> Self {
+        self.name = name.to_string();
+        self
     }
 }

--- a/examples/match_no_continue_tx.rs
+++ b/examples/match_no_continue_tx.rs
@@ -1,6 +1,6 @@
 use transistor::client::Crux;
 use transistor::edn_rs::{ser_struct, Serialize};
-use transistor::types::http::Action;
+use transistor::types::http::Actions;
 use transistor::types::{
     error::CruxError,
     {query::Query, CruxId},
@@ -14,8 +14,9 @@ fn main() -> Result<(), CruxError> {
     };
 
     let client = Crux::new("localhost", "3000").http_client();
-    let put_action = Action::put(crux.clone());
-    let _ = client.tx_log(vec![put_action])?;
+    let actions = Actions::new().append_put(crux.clone());
+
+    let _ = client.tx_log(actions)?;
 
     let query = Query::find(vec!["?d"])?
         .where_clause(vec!["?d :is-sql false"])?
@@ -29,9 +30,11 @@ fn main() -> Result<(), CruxError> {
     // Map(Map({":crux.db/id": Key(":crux"), ":is-sql": Bool(false), ":name": Str("Crux Datalog")}))
 
     crux.name = "banana".to_string();
-    let match_action = Action::match_doc(CruxId::new(":crux"), crux.clone());
-    let put_action = Action::put(crux.clone());
-    let result = client.tx_log(vec![match_action, put_action])?;
+    let actions = Actions::new()
+        .append_match_doc(CruxId::new(":crux"), crux.clone())
+        .append_put(crux.clone());
+
+    let result = client.tx_log(actions)?;
 
     println!("{:?}", result);
     // TxLogResponse { tx___tx_id: 54, tx___tx_time: "2020-08-09T03:54:20.730-00:00", tx__event___tx_events: None }

--- a/examples/simple_query.rs
+++ b/examples/simple_query.rs
@@ -1,6 +1,6 @@
 use transistor::client::Crux;
 use transistor::edn_rs::{ser_struct, Serialize};
-use transistor::types::http::Action;
+use transistor::types::http::Actions;
 use transistor::types::{
     error::CruxError,
     {query::Query, CruxId},
@@ -32,12 +32,13 @@ fn main() -> Result<(), CruxError> {
     // "{ :crux.db/id :mysql, :name \"MySQL\", :is-sql true, }"
 
     let client = Crux::new("localhost", "3000").http_client();
-    let action1 = Action::put(crux);
-    let action2 = Action::put(psql);
-    let action3 = Action::put(mysql);
+    let actions = Actions::new()
+        .append_put(crux)
+        .append_put(psql)
+        .append_put(mysql);
 
-    let _ = client.tx_log(vec![action1, action2, action3])?;
-    // Request body for vec![action1, action2]
+    let _ = client.tx_log(actions)?;
+    // Request body for actions
     // "[[:crux.tx/put { :crux.db/id :crux, :name \"Crux Datalog\", :is-sql false, }],
     //   [:crux.tx/put { :crux.db/id :mysql, :name \"MySQL\", :is-sql true, }],
     //   [:crux.tx/put { :crux.db/id :postgres, :name \"Postgres\", :is-sql true, }]]"

--- a/examples/tx_log.rs
+++ b/examples/tx_log.rs
@@ -1,6 +1,6 @@
 use transistor::client::Crux;
 use transistor::edn_rs::{ser_struct, Serialize};
-use transistor::types::http::Action;
+use transistor::types::http::Actions;
 use transistor::types::CruxId;
 
 fn main() {
@@ -20,14 +20,13 @@ fn main() {
     println!("{:?}", edn_rs::to_string(person2.clone()));
     //"{ :crux.db/id :manuel-1, :first-name \"Diego\", :last-name \"Manuel\", }"
 
-    let action1 = Action::put(person1);
-    let action2 = Action::put(person2);
+    let actions = Actions::new().append_put(person1).append_put(person2);
 
     let body = Crux::new("localhost", "3000")
         .http_client()
-        .tx_log(vec![action1, action2])
+        .tx_log(actions)
         .unwrap();
-    // Request body for vec![action1, action2]
+    // Request body for Actions
     // "[[:crux.tx/put { :crux.db/id :jorge-3, :first-name \"Michael\", :last-name \"Jorge\", }],
     //   [:crux.tx/put { :crux.db/id :manuel-1, :first-name \"Diego\", :last-name \"Manuel\", }]]"
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -36,6 +36,11 @@ impl HttpClient {
     /// to CruxDB.
     /// The "write" endpoint, to post transactions.
     pub fn tx_log(&self, actions: Actions) -> Result<TxLogResponse, CruxError> {
+        if actions.is_empty() {
+            return Err(CruxError::TxLogActionError(
+                "Actions cannont be empty.".to_string(),
+            ));
+        }
         let body = actions.build();
 
         let resp = self
@@ -237,6 +242,12 @@ impl HttpClient {
 #[cfg(feature = "async")]
 impl HttpClient {
     pub async fn tx_log(&self, actions: Actions) -> Result<TxLogResponse, CruxError> {
+        if actions.is_empty() {
+            return Err(CruxError::TxLogActionError(
+                "Actions cannont be empty.".to_string(),
+            ));
+        }
+
         let body = actions.build();
 
         let resp = self
@@ -516,6 +527,15 @@ mod http {
         let response = Crux::new("localhost", "4000").http_client().tx_log(actions);
 
         assert_eq!(response.unwrap(), TxLogResponse::default())
+    }
+
+    #[test]
+    #[should_panic(expected = "TxLogActionError(\"Actions cannont be empty.\")")]
+    fn empty_actions_on_tx_log() {
+        let actions = Actions::new();
+
+        let err = Crux::new("localhost", "4000").http_client().tx_log(actions);
+        err.unwrap();
     }
 
     #[test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -38,7 +38,7 @@ impl HttpClient {
     pub fn tx_log(&self, actions: Actions) -> Result<TxLogResponse, CruxError> {
         if actions.is_empty() {
             return Err(CruxError::TxLogActionError(
-                "Actions cannont be empty.".to_string(),
+                "Actions cannot be empty.".to_string(),
             ));
         }
         let body = actions.build();
@@ -244,7 +244,7 @@ impl HttpClient {
     pub async fn tx_log(&self, actions: Actions) -> Result<TxLogResponse, CruxError> {
         if actions.is_empty() {
             return Err(CruxError::TxLogActionError(
-                "Actions cannont be empty.".to_string(),
+                "Actions cannot be empty.".to_string(),
             ));
         }
 
@@ -530,7 +530,7 @@ mod http {
     }
 
     #[test]
-    #[should_panic(expected = "TxLogActionError(\"Actions cannont be empty.\")")]
+    #[should_panic(expected = "TxLogActionError(\"Actions cannot be empty.\")")]
     fn empty_actions_on_tx_log() {
         let actions = Actions::new();
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -36,22 +36,13 @@ impl HttpClient {
     /// to CruxDB.
     /// The "write" endpoint, to post transactions.
     pub fn tx_log(&self, actions: Actions) -> Result<TxLogResponse, CruxError> {
-        let actions_str = actions
-            .build()
-            .into_iter()
-            .map(edn_rs::to_string)
-            .collect::<Vec<String>>()
-            .join(", ");
-        let mut s = String::new();
-        s.push_str("[");
-        s.push_str(&actions_str);
-        s.push_str("]");
+        let body = actions.build();
 
         let resp = self
             .client
             .post(&format!("{}/tx-log", self.uri))
             .headers(self.headers.clone())
-            .body(s)
+            .body(body)
             .send()?
             .text()?;
 
@@ -246,22 +237,13 @@ impl HttpClient {
 #[cfg(feature = "async")]
 impl HttpClient {
     pub async fn tx_log(&self, actions: Actions) -> Result<TxLogResponse, CruxError> {
-        let actions_str = actions
-            .build()
-            .into_iter()
-            .map(edn_rs::to_string)
-            .collect::<Vec<String>>()
-            .join(", ");
-        let mut s = String::new();
-        s.push_str("[");
-        s.push_str(&actions_str);
-        s.push_str("]");
+        let body = actions.build();
 
         let resp = self
             .client
             .post(&format!("{}/tx-log", self.uri))
             .headers(self.headers.clone())
-            .body(s)
+            .body(body)
             .send()
             .await?
             .text()

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -16,6 +16,8 @@ pub enum CruxError {
     QueryError(String),
     /// Provided Query struct did not match schema.
     QueryFormatError(String),
+    /// Provided Actions cannot be empty.
+    TxLogActionError(String),
 }
 
 impl std::error::Error for CruxError {
@@ -27,6 +29,7 @@ impl std::error::Error for CruxError {
             CruxError::QueryError(s) => &s,
             CruxError::QueryFormatError(s) => &s,
             CruxError::IterError(s) => &s,
+            CruxError::TxLogActionError(s) => &s,
         }
     }
 
@@ -44,6 +47,7 @@ impl std::fmt::Display for CruxError {
             CruxError::QueryError(s) => write!(f, "{}", &s),
             CruxError::QueryFormatError(s) => write!(f, "{}", &s),
             CruxError::IterError(s) => write!(f, "{}", &s),
+            CruxError::TxLogActionError(s) => write!(f, "{}", &s),
         }
     }
 }

--- a/src/types/http.rs
+++ b/src/types/http.rs
@@ -1,7 +1,10 @@
+use crate::types::CruxId;
 use chrono::prelude::*;
 use edn_rs::Serialize;
+
 static ACTION_DATE_FORMAT: &'static str = "%Y-%m-%dT%H:%M:%S%Z";
 static DATETIME_FORMAT: &'static str = "%Y-%m-%dT%H:%M:%S";
+
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) enum Action {
     Put(String, Option<DateTime<FixedOffset>>),
@@ -56,29 +59,25 @@ impl Actions {
     }
 
     /// Appends an `Action::Delete` enforcing types for `id` field to be a `CruxId`
-    pub fn append_delete(mut self, id: crate::types::CruxId) -> Self {
+    pub fn append_delete(mut self, id: CruxId) -> Self {
         self.actions.push(Action::delete(id));
         self
     }
 
     /// Appends an `Action::Delete` that includes `date` enforcing types for `id` field to be a `CruxId` and `date` to be `DateTime<FixedOffset>`.
-    pub fn append_delete_timed(
-        mut self,
-        id: crate::types::CruxId,
-        date: DateTime<FixedOffset>,
-    ) -> Self {
+    pub fn append_delete_timed(mut self, id: CruxId, date: DateTime<FixedOffset>) -> Self {
         self.actions.push(Action::delete(id).with_valid_date(date));
         self
     }
 
     /// Appends an `Action::Evict` enforcing types for `id` field to be a `CruxId`
-    pub fn append_evict(mut self, id: crate::types::CruxId) -> Self {
+    pub fn append_evict(mut self, id: CruxId) -> Self {
         self.actions.push(Action::evict(id));
         self
     }
 
     /// Appends an `Action::Match` enforcing types for `id` field to be a `CruxId` and `action` field to be a `T: Serialize`
-    pub fn append_match_doc<T: Serialize>(mut self, id: crate::types::CruxId, action: T) -> Self {
+    pub fn append_match_doc<T: Serialize>(mut self, id: CruxId, action: T) -> Self {
         self.actions.push(Action::match_doc(id, action));
         self
     }
@@ -86,7 +85,7 @@ impl Actions {
     /// Appends an `Action::Match` that includes `date` enforcing types for `id` field to be a `CruxId`, `action` field to be a `T: Serialize` and `date` to be `DateTime<FixedOffset>`.
     pub fn append_match_doc_timed<T: Serialize>(
         mut self,
-        id: crate::types::CruxId,
+        id: CruxId,
         action: T,
         date: DateTime<FixedOffset>,
     ) -> Self {
@@ -124,15 +123,15 @@ impl Action {
         }
     }
 
-    fn delete(id: crate::types::CruxId) -> Action {
+    fn delete(id: CruxId) -> Action {
         Action::Delete(edn_rs::to_string(id), None)
     }
 
-    fn evict(id: crate::types::CruxId) -> Action {
+    fn evict(id: CruxId) -> Action {
         Action::Evict(edn_rs::to_string(id))
     }
 
-    fn match_doc<T: Serialize>(id: crate::types::CruxId, action: T) -> Action {
+    fn match_doc<T: Serialize>(id: CruxId, action: T) -> Action {
         Action::Match(edn_rs::to_string(id), edn_rs::to_string(action), None)
     }
 }

--- a/src/types/http.rs
+++ b/src/types/http.rs
@@ -99,17 +99,7 @@ impl Actions {
     }
 
     pub(crate) fn build(self) -> String {
-        let actions_str = self
-            .actions
-            .into_iter()
-            .map(edn_rs::to_string)
-            .collect::<Vec<String>>()
-            .join(", ");
-
-        let mut s = String::from("[");
-        s.push_str(&actions_str);
-        s.push_str("]");
-        s
+        edn_rs::to_string(self.actions)
     }
 }
 

--- a/src/types/http.rs
+++ b/src/types/http.rs
@@ -95,8 +95,18 @@ impl Actions {
         self
     }
 
-    pub(crate) fn build(self) -> Vec<Action> {
-        self.actions
+    pub(crate) fn build(self) -> String {
+        let actions_str = self
+            .actions
+            .into_iter()
+            .map(edn_rs::to_string)
+            .collect::<Vec<String>>()
+            .join(", ");
+
+        let mut s = String::from("[");
+        s.push_str(&actions_str);
+        s.push_str("]");
+        s
     }
 }
 

--- a/src/types/http.rs
+++ b/src/types/http.rs
@@ -2,16 +2,6 @@ use chrono::prelude::*;
 use edn_rs::Serialize;
 static ACTION_DATE_FORMAT: &'static str = "%Y-%m-%dT%H:%M:%S%Z";
 static DATETIME_FORMAT: &'static str = "%Y-%m-%dT%H:%M:%S";
-
-/// Action to perform in Crux. Receives a serialized Edn.
-///
-/// **First field of your struct should be `crux__db___id: CruxId`**
-///
-/// Allowed actions:
-/// * `PUT` - Write a version of a document can receive an `Option<DateTime<FixedOffset>>` as second argument which corresponds to a `valid-time`.
-/// * `Delete` - Deletes the specific document at a given valid time, if `Option<DateTime<FixedOffset>>` is `None` it deletes the last `valid-`time` else it deletes the passed `valid-time`.
-/// * `Evict` - Evicts a document entirely, including all historical versions (receives only the ID to evict).
-/// * `Match` - Matches the current state of an entity, if the state doesn't match the provided document, the transaction will not continue. First argument is struct's `crux__db___id`,  the second is the serialized document that you want to match and the third argument is an `Option<DateTime<FixedOffset>>` which corresponds to a `valid-time` for the `Match`
 #[derive(Debug, PartialEq)]
 pub(crate) enum Action {
     Put(String, Option<DateTime<FixedOffset>>),
@@ -20,6 +10,7 @@ pub(crate) enum Action {
     Match(String, String, Option<DateTime<FixedOffset>>),
 }
 
+/// Test enum to debug Actions
 #[cfg(feature = "mock")]
 #[derive(Debug, PartialEq)]
 pub enum ActionMock {
@@ -29,6 +20,13 @@ pub enum ActionMock {
     Match(String, String, Option<DateTime<FixedOffset>>),
 }
 
+/// Actions to perform in Crux. It is a builder struct to help you create a `Vec<Action>` for `tx_log`.
+///
+/// Allowed actions:
+/// * `PUT` - Write a version of a document. Functions are `append_put` and `append_put_timed`.
+/// * `Delete` - Deletes the specific document at a given valid time. Functions are `append_delete` and `append_delete_timed`.
+/// * `Evict` - Evicts a document entirely, including all historical versions (receives only the ID to evict). Function is `append_evict`.
+/// * `Match` - Matches the current state of an entity, if the state doesn't match the provided document, the transaction will not continue. Functions are `append_match` and `append_match_timed`.
 pub struct Actions {
     actions: Vec<Action>,
 }

--- a/src/types/http.rs
+++ b/src/types/http.rs
@@ -42,6 +42,10 @@ impl Actions {
         }
     }
 
+    pub(crate) fn is_empty(&self) -> bool {
+        self.actions.is_empty()
+    }
+
     /// Appends an `Action::Put` enforcing types for `action` field to be a `T: Serialize`
     pub fn append_put<T: Serialize>(mut self, action: T) -> Self {
         self.actions.push(Action::put(action));

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -41,4 +41,4 @@ impl CruxId {
     }
 }
 
-pub use http::{Action, Order};
+pub use http::{Actions, Order};

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -194,9 +194,9 @@ mod integration {
         };
 
         vec![
-            ActionMock::Put(person1.clone().serialize(), None),
-            ActionMock::Put(person2.serialize(), None),
-            ActionMock::Delete(person1.crux__db___id.serialize(), None),
+            ActionMock::Put(edn_rs::to_string(person1.clone()), None),
+            ActionMock::Put(edn_rs::to_string(person2), None),
+            ActionMock::Delete(edn_rs::to_string(person1.crux__db___id), None),
         ]
     }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,7 +5,7 @@ mod integration {
     use transistor::client::Crux;
     use transistor::edn_rs::{ser_struct, Serialize};
     use transistor::types::http::TimeHistory;
-    use transistor::types::http::{Actions, Order};
+    use transistor::types::http::{ActionMock, Actions, Order};
     use transistor::types::CruxId;
 
     #[test]
@@ -170,6 +170,43 @@ mod integration {
             );
 
         m.assert();
+    }
+
+    #[test]
+    fn test_actions_eq_actions_mock() {
+        let actions = test_actions();
+        let mock = test_action_mock();
+
+        assert_eq!(actions, mock);
+    }
+
+    fn test_action_mock() -> Vec<ActionMock> {
+        let person1 = Person {
+            crux__db___id: CruxId::new("jorge-3"),
+            first_name: "Michael".to_string(),
+            last_name: "Jorge".to_string(),
+        };
+
+        let person2 = Person {
+            crux__db___id: CruxId::new("manuel-1"),
+            first_name: "Diego".to_string(),
+            last_name: "Manuel".to_string(),
+        };
+
+        vec![
+            ActionMock::Put(person1.clone().serialize(), None),
+            ActionMock::Put(person2.serialize(), None),
+            ActionMock::Delete(person1.crux__db___id.serialize(), None),
+        ]
+    }
+
+    fn test_actions() -> Actions {
+        let person1 = Person {
+            crux__db___id: CruxId::new("jorge-3"),
+            first_name: "Michael".to_string(),
+            last_name: "Jorge".to_string(),
+        };
+        actions().append_delete(person1.crux__db___id)
     }
 
     fn actions() -> Actions {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,7 +5,7 @@ mod integration {
     use transistor::client::Crux;
     use transistor::edn_rs::{ser_struct, Serialize};
     use transistor::types::http::TimeHistory;
-    use transistor::types::http::{Action, Order};
+    use transistor::types::http::{Actions, Order};
     use transistor::types::CruxId;
 
     #[test]
@@ -172,7 +172,7 @@ mod integration {
         m.assert();
     }
 
-    fn actions() -> Vec<Action> {
+    fn actions() -> Actions {
         let person1 = Person {
             crux__db___id: CruxId::new("jorge-3"),
             first_name: "Michael".to_string(),
@@ -185,7 +185,7 @@ mod integration {
             last_name: "Manuel".to_string(),
         };
 
-        vec![Action::put(person1), Action::put(person2)]
+        Actions::new().append_put(person1).append_put(person2)
     }
 
     ser_struct! {


### PR DESCRIPTION
Now instead of creating every action individually like:
```rust
let action1 = Action::Put(edn_rs::to_string(person1), None);
    let action2 = Action::Put(edn_rs::to_string(person2), None);

    let body = Crux::new("localhost", "3000")
        .http_client()
        .tx_log(vec![action1, action2])
        .await
        .unwrap();
```

they are created via type `Actions` that is `tx_log` argument, like:
```rust
let actions = Actions::new().append_put(person1).append_put(person2);

    let body = Crux::new("localhost", "3000")
        .http_client()
        .tx_log(actions)
        .await
        .unwrap();
```
* Now `Action` is **private**.

**Why?** to reduce chance of a user sending any string to Action as well as to `tx_log`.

